### PR TITLE
Extract shared game types and storage constants

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,6 +56,7 @@ import { deleteTournament as utilDeleteTournament, updateTournament as utilUpdat
 // Import Player from types directory
 import { Player, Season, Tournament } from '@/types';
 // Import saveMasterRoster utility
+import type { Point, Opponent, GameEvent, IntervalLog, AppState, TacticalDisc, SavedGamesCollection, TimerState } from "@/types";
 import { saveMasterRoster } from '@/utils/masterRoster';
 // Import useQuery, useMutation, useQueryClient
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -65,95 +66,9 @@ import { getLocalStorageItemAsync, setLocalStorageItemAsync, removeLocalStorageI
 import { queryKeys } from '@/config/queryKeys';
 // Also import addSeason and addTournament for the new mutations
 import { updateGameDetails as utilUpdateGameDetails } from '@/utils/savedGames';
-// Import constants
-import { DEFAULT_GAME_ID, MASTER_ROSTER_KEY, TIMER_STATE_KEY } from '@/config/constants';
+import { DEFAULT_GAME_ID } from '@/config/constants';
+import { MASTER_ROSTER_KEY, TIMER_STATE_KEY, SEASONS_LIST_KEY } from "@/config/storageKeys";
 
-// Define the Point type for drawing - Use relative coordinates
-export interface Point {
-  relX: number; // Relative X (0.0 to 1.0)
-  relY: number; // Relative Y (0.0 to 1.0)
-}
-
-// Define the Opponent type - Use relative coordinates
-export interface Opponent {
-  id: string;
-  relX: number; // Relative X (0.0 to 1.0)
-  relY: number; // Relative Y (0.0 to 1.0)
-}
-
-// Define the structure for a game event
-export interface GameEvent {
-  id: string; // Unique ID for the event
-  type: 'goal' | 'opponentGoal' | 'substitution' | 'periodEnd' | 'gameEnd' | 'fairPlayCard'; // Added fairPlayCard
-  time: number; // Time in seconds relative to the start of the game
-  scorerId?: string; // Player ID of the scorer (optional)
-  assisterId?: string; // Player ID of the assister (optional)
-  entityId?: string; // Optional: For events associated with a specific entity (e.g., player ID for fair play card)
-  // Additional fields might be needed for other event types
-}
-
-// Define the structure for the timer state snapshot
-interface TimerState {
-  gameId: string;
-  timeElapsedInSeconds: number;
-  timestamp: number; // The Date.now() when the state was saved
-}
-
-// Define structure for substitution interval logs
-export interface IntervalLog {
-  period: number;
-  duration: number; // Duration in seconds
-  timestamp: number; // Unix timestamp when the interval ended
-}
-
-// Define the structure for the application state (for history)
-export interface AppState {
-  playersOnField: Player[];
-  opponents: Opponent[]; 
-  drawings: Point[][];
-  availablePlayers: Player[]; // <<< RE-ADD: Roster at the time of saving
-  showPlayerNames: boolean; 
-  teamName: string; 
-  gameEvents: GameEvent[]; // Add game events to state
-  // Add game info state
-  opponentName: string;
-  gameDate: string;
-  homeScore: number;
-  awayScore: number;
-  gameNotes: string; // Add game notes to state
-  homeOrAway: 'home' | 'away'; // <<< Step 1: Add field
-  // Add game structure state
-  numberOfPeriods: 1 | 2;
-  periodDurationMinutes: number;
-  currentPeriod: number; // 1 or 2
-  gameStatus: 'notStarted' | 'inProgress' | 'periodEnd' | 'gameEnd';
-  selectedPlayerIds: string[]; // IDs of players selected for the current match
-  // Replace gameType with required IDs, initialized as empty string
-  seasonId: string; 
-  tournamentId: string;
-  // NEW: Optional fields for location and time
-  gameLocation?: string;
-  gameTime?: string; 
-  // Timer related state to persist (NON-VOLATILE ONES)
-  subIntervalMinutes?: number; // Add sub interval
-  completedIntervalDurations?: IntervalLog[]; // Add completed interval logs
-  lastSubConfirmationTimeSeconds?: number; // Add last substitution confirmation time
-  // VOLATILE TIMER STATES REMOVED:
-  // timeElapsedInSeconds?: number;
-  // isTimerRunning?: boolean;
-  // nextSubDueTimeSeconds?: number;
-  // subAlertLevel?: 'none' | 'warning' | 'due';
-  tacticalDiscs: TacticalDisc[];
-  tacticalDrawings: Point[][];
-  tacticalBallPosition: Point | null;
-}
-
-export interface TacticalDisc {
-  id: string;
-  relX: number;
-  relY: number;
-  type: 'home' | 'opponent' | 'goalie';
-}
 
 // Placeholder data - Initialize new fields
 const initialAvailablePlayersData: Player[] = [
@@ -206,24 +121,6 @@ const initialState: AppState = {
   tacticalBallPosition: { relX: 0.5, relY: 0.5 },
 };
 
-// Define new localStorage keys
-const SEASONS_LIST_KEY = 'soccerSeasons';
-// const TOURNAMENTS_LIST_KEY = 'soccerTournaments'; // Removed unused variable
-// const MASTER_ROSTER_KEY = 'soccerMasterRoster'; // <<< NEW KEY for global roster - now imported from constants
-
-// Define structure for settings
-// interface AppSettings {
-//   currentGameId: string | null;
-//   // Add other non-game-specific settings here later if needed
-//   // e.g., preferredLanguage: string;
-// }
-
-// Define structure for saved games collection
-export interface SavedGamesCollection {
-  [gameId: string]: AppState; // Use AppState for the game state structure
-}
-
-// Define a default Game ID for the initial/unsaved state - now imported from constants
 
 
 

--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 import { HiPlusCircle } from 'react-icons/hi2';
 import { Season, Tournament, Player } from '@/types';
-import { AppState } from '@/app/page';
+import { AppState } from '@/types';
 import { getSeasons } from '@/utils/seasons';
 import { getTournaments } from '@/utils/tournaments';
 import { updateGameDetails, updateGameEvent, removeGameEvent } from '@/utils/savedGames';

--- a/src/components/GameStatsModal.test.tsx
+++ b/src/components/GameStatsModal.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor, within, fireEvent, act } from '@testing-librar
 import '@testing-library/jest-dom';
 import GameStatsModal from './GameStatsModal';
 import { Player, Season, Tournament } from '@/types';
-import { GameEvent, SavedGamesCollection, AppState } from '@/app/page';
+import { GameEvent, SavedGamesCollection, AppState } from '@/types';
 import * as seasonsUtils from '@/utils/seasons';
 import * as tournamentsUtils from '@/utils/tournaments';
 import { I18nextProvider } from 'react-i18next';

--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next';
 // Import types from the types directory
 import { Player, PlayerStatRow, Season, Tournament } from '@/types';
-import { GameEvent, SavedGamesCollection } from '@/app/page';
+import { GameEvent, SavedGamesCollection } from '@/types';
 // ADD new import for keys
 // import { SEASONS_LIST_KEY, TOURNAMENTS_LIST_KEY } from '@/config/constants';
 // <<< REMOVE unused key imports

--- a/src/components/LoadGameModal.test.tsx
+++ b/src/components/LoadGameModal.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import LoadGameModal from './LoadGameModal';
-import { SavedGamesCollection, AppState } from '@/app/page';
+import { SavedGamesCollection, AppState } from '@/types';
 import { Season, Tournament } from '@/types';
 
 // Mock react-i18next

--- a/src/components/LoadGameModal.tsx
+++ b/src/components/LoadGameModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { SavedGamesCollection } from '@/app/page'; // Keep this if SavedGamesCollection is from here
+import { SavedGamesCollection } from '@/types'; // Keep this if SavedGamesCollection is from here
 import { Season, Tournament } from '@/types'; // Corrected import path
 import { 
   HiOutlineDocumentArrowDown, 

--- a/src/components/PlayerBar.test.tsx
+++ b/src/components/PlayerBar.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import PlayerBar from './PlayerBar';
 import { Player } from '@/types';
-import { GameEvent } from '@/app/page';
+import { GameEvent } from '@/types';
 
 // Mock next/image since it's used in the component
 jest.mock('next/image', () => ({

--- a/src/components/PlayerBar.tsx
+++ b/src/components/PlayerBar.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PlayerDisk from './PlayerDisk'; // Import the PlayerDisk component
 import type { Player } from '@/types'; // Import the Player type from central types
 import Image from 'next/image'; // RE-ADD Import
-import type { GameEvent } from '@/app/page'; // Correctly import GameEvent type
+import type { GameEvent } from '@/types'; // Correctly import GameEvent type
 // REMOVED unused import
 // import Image from 'next/image'; 
 

--- a/src/components/PlayerDisk.tsx
+++ b/src/components/PlayerDisk.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo } from 'react';
 import { Player } from '@/types'; // Import Player from types
-import { GameEvent } from '@/app/page'; // Import GameEvent type
+import { GameEvent } from '@/types'; // Import GameEvent type
 import {
     HiOutlineShieldCheck, // Goalie icon
 } from 'react-icons/hi2';

--- a/src/components/PlayerStatsView.tsx
+++ b/src/components/PlayerStatsView.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Player, Season, Tournament } from '@/types';
-import { AppState } from '@/app/page';
+import { AppState } from '@/types';
 import { calculatePlayerStats, PlayerStats as PlayerStatsData } from '@/utils/playerStats';
 import { format } from 'date-fns';
 import { fi, enUS } from 'date-fns/locale';

--- a/src/components/SoccerField.test.tsx
+++ b/src/components/SoccerField.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SoccerField from './SoccerField';
 import { Player } from '@/types';
-import { Point, Opponent } from '@/app/page';
+import { Point, Opponent } from '@/types';
 
 // Mock ResizeObserver
 global.ResizeObserver = class ResizeObserver {

--- a/src/components/SoccerField.tsx
+++ b/src/components/SoccerField.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Player } from '@/types'; // Import Player from types
-import { Point, Opponent, TacticalDisc } from '@/app/page'; // Import Point and Opponent from page
+import { Point, Opponent, TacticalDisc } from '@/types'; // Import Point and Opponent from page
 import tinycolor from 'tinycolor2';
 
 // Define props for SoccerField

--- a/src/components/TimerOverlay.tsx
+++ b/src/components/TimerOverlay.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { FaPlay, FaPause, FaUndo } from 'react-icons/fa'; // Import icons
 import { useTranslation } from 'react-i18next'; // Import translation hook
-import { IntervalLog } from '@/app/page'; // Import the IntervalLog interface
+import { IntervalLog } from '@/types'; // Import the IntervalLog interface
 
 // Helper function to format time (copied from ControlBar for now)
 // TODO: Consider moving to a shared utility file

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,9 +1,1 @@
-export const SEASONS_LIST_KEY = 'soccerSeasons';
-export const TOURNAMENTS_LIST_KEY = 'soccerTournaments'; 
-// Add other core keys
-export const SAVED_GAMES_KEY = 'savedSoccerGames';
-export const APP_SETTINGS_KEY = 'soccerAppSettings';
-export const MASTER_ROSTER_KEY = 'soccerMasterRoster'; 
-export const LAST_HOME_TEAM_NAME_KEY = 'lastHomeTeamName'; 
-export const DEFAULT_GAME_ID = 'unsaved_game'; 
-export const TIMER_STATE_KEY = 'soccerTimerState'; 
+export const DEFAULT_GAME_ID = 'unsaved_game';

--- a/src/config/storageKeys.ts
+++ b/src/config/storageKeys.ts
@@ -1,0 +1,7 @@
+export const SEASONS_LIST_KEY = 'soccerSeasons';
+export const TOURNAMENTS_LIST_KEY = 'soccerTournaments';
+export const SAVED_GAMES_KEY = 'savedSoccerGames';
+export const APP_SETTINGS_KEY = 'soccerAppSettings';
+export const MASTER_ROSTER_KEY = 'soccerMasterRoster';
+export const LAST_HOME_TEAM_NAME_KEY = 'lastHomeTeamName';
+export const TIMER_STATE_KEY = 'soccerTimerState';

--- a/src/hooks/useGameSessionReducer.ts
+++ b/src/hooks/useGameSessionReducer.ts
@@ -1,4 +1,4 @@
-import { GameEvent } from '@/app/page'; // Assuming AppState might be useful context
+import { GameEvent } from '@/types'; // Assuming AppState might be useful context
 
 // --- State Definition ---
 export interface GameSessionState {

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -5,7 +5,7 @@ import {
     Opponent,
     Point,
     AppState,
-} from '@/app/page'; // Reverted for Opponent, Point, AppState as they are likely still in page.tsx exports
+} from '@/types'; // Reverted for Opponent, Point, AppState as they are likely still in page.tsx exports
 import { 
     updatePlayer as updatePlayerInMasterRoster, 
     getMasterRoster as getMasterRosterFromManager,

--- a/src/types/__tests__/moduleResolution.test.ts
+++ b/src/types/__tests__/moduleResolution.test.ts
@@ -1,0 +1,40 @@
+import { DEFAULT_GAME_ID } from '@/config/constants';
+import {
+  SEASONS_LIST_KEY,
+  TOURNAMENTS_LIST_KEY,
+  SAVED_GAMES_KEY,
+  APP_SETTINGS_KEY,
+  MASTER_ROSTER_KEY,
+  LAST_HOME_TEAM_NAME_KEY,
+  TIMER_STATE_KEY,
+} from '@/config/storageKeys';
+import type {
+  Point,
+  Opponent,
+  GameEvent,
+  IntervalLog,
+  AppState,
+  TacticalDisc,
+  SavedGamesCollection,
+  TimerState,
+} from '@/types';
+
+// Dummy variable to ensure type imports are used
+const _dummy: {
+  point?: Point;
+  opponent?: Opponent;
+  event?: GameEvent;
+  log?: IntervalLog;
+  state?: AppState;
+  disc?: TacticalDisc;
+  collection?: SavedGamesCollection;
+  timer?: TimerState;
+} = {};
+
+describe('module resolution', () => {
+  it('resolves constants and types', () => {
+    expect(typeof DEFAULT_GAME_ID).toBe('string');
+    expect(SEASONS_LIST_KEY).toBeDefined();
+    expect(_dummy).toBeDefined();
+  });
+});

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,74 @@
+import type { Player } from "./index";
+export interface Point {
+  relX: number;
+  relY: number;
+}
+
+export interface Opponent {
+  id: string;
+  relX: number;
+  relY: number;
+}
+
+export interface GameEvent {
+  id: string;
+  type: 'goal' | 'opponentGoal' | 'substitution' | 'periodEnd' | 'gameEnd' | 'fairPlayCard';
+  time: number;
+  scorerId?: string;
+  assisterId?: string;
+  entityId?: string;
+}
+
+export interface TimerState {
+  gameId: string;
+  timeElapsedInSeconds: number;
+  timestamp: number;
+}
+
+export interface IntervalLog {
+  period: number;
+  duration: number;
+  timestamp: number;
+}
+
+export interface TacticalDisc {
+  id: string;
+  relX: number;
+  relY: number;
+  type: 'home' | 'opponent' | 'goalie';
+}
+
+export interface AppState {
+  playersOnField: Player[];
+  opponents: Opponent[];
+  drawings: Point[][];
+  availablePlayers: Player[];
+  showPlayerNames: boolean;
+  teamName: string;
+  gameEvents: GameEvent[];
+  opponentName: string;
+  gameDate: string;
+  homeScore: number;
+  awayScore: number;
+  gameNotes: string;
+  homeOrAway: 'home' | 'away';
+  numberOfPeriods: 1 | 2;
+  periodDurationMinutes: number;
+  currentPeriod: number;
+  gameStatus: 'notStarted' | 'inProgress' | 'periodEnd' | 'gameEnd';
+  selectedPlayerIds: string[];
+  seasonId: string;
+  tournamentId: string;
+  gameLocation?: string;
+  gameTime?: string;
+  subIntervalMinutes?: number;
+  completedIntervalDurations?: IntervalLog[];
+  lastSubConfirmationTimeSeconds?: number;
+  tacticalDiscs: TacticalDisc[];
+  tacticalDrawings: Point[][];
+  tacticalBallPosition: Point | null;
+}
+
+export interface SavedGamesCollection {
+  [gameId: string]: AppState;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,3 +29,4 @@ export interface Tournament {
   id: string; 
   name: string; 
 } 
+export * from "./game";

--- a/src/utils/appSettings.test.ts
+++ b/src/utils/appSettings.test.ts
@@ -9,7 +9,7 @@ import {
   resetAppSettings,
   AppSettings
 } from './appSettings';
-import { APP_SETTINGS_KEY, LAST_HOME_TEAM_NAME_KEY } from '@/config/constants';
+import { APP_SETTINGS_KEY, LAST_HOME_TEAM_NAME_KEY } from '@/config/storageKeys';
 
 describe('App Settings Utilities', () => {
   // Mock localStorage

--- a/src/utils/appSettings.ts
+++ b/src/utils/appSettings.ts
@@ -5,8 +5,7 @@ import {
   SAVED_GAMES_KEY,
   SEASONS_LIST_KEY,
   TOURNAMENTS_LIST_KEY,
-} from '@/config/constants';
-
+} from '@/config/storageKeys';
 /**
  * Interface for application settings
  */

--- a/src/utils/fullBackup.test.ts
+++ b/src/utils/fullBackup.test.ts
@@ -6,7 +6,7 @@ import {
   SEASONS_LIST_KEY, 
   TOURNAMENTS_LIST_KEY, 
   MASTER_ROSTER_KEY 
-} from '@/config/constants'; // Using path alias from jest.config.js
+} from '@/config/storageKeys'; // Using path alias from jest.config.js
 
 // Mock localStorage globally for all tests in this file
 const localStorageMock = (() => {

--- a/src/utils/fullBackup.ts
+++ b/src/utils/fullBackup.ts
@@ -1,4 +1,4 @@
-import { SavedGamesCollection } from '@/app/page'; // AppState was removed, SavedGamesCollection is still used.
+import { SavedGamesCollection } from '@/types'; // AppState was removed, SavedGamesCollection is still used.
 import { Player, Season, Tournament } from '@/types'; // Corrected import path for these types
 // Import the constants from the central file
 import { 
@@ -7,7 +7,7 @@ import {
   SEASONS_LIST_KEY, 
   TOURNAMENTS_LIST_KEY, 
   MASTER_ROSTER_KEY 
-} from '@/config/constants';
+} from '@/config/storageKeys';
 // Import the new async localStorage utility functions
 import { getLocalStorageItemAsync, setLocalStorageItemAsync, removeLocalStorageItemAsync } from './localStorage';
 

--- a/src/utils/game.test.ts
+++ b/src/utils/game.test.ts
@@ -1,4 +1,4 @@
-import { AppState } from '@/app/page';
+import { AppState } from '@/types';
 
 // Define placeholder functions for the logic being tested.
 // Use unknown for state parameter and perform type checking inside if needed

--- a/src/utils/masterRoster.test.ts
+++ b/src/utils/masterRoster.test.ts
@@ -7,7 +7,7 @@ import {
   setPlayerGoalieStatus,
   setPlayerFairPlayCardStatus
 } from './masterRoster';
-import { MASTER_ROSTER_KEY } from '@/config/constants';
+import { MASTER_ROSTER_KEY } from '@/config/storageKeys';
 import type { Player } from '@/types';
 
 describe('Master Roster Utilities', () => {

--- a/src/utils/masterRoster.ts
+++ b/src/utils/masterRoster.ts
@@ -1,4 +1,4 @@
-import { MASTER_ROSTER_KEY } from '@/config/constants';
+import { MASTER_ROSTER_KEY } from '@/config/storageKeys';
 import type { Player } from '@/types';
 
 /**

--- a/src/utils/playerStats.ts
+++ b/src/utils/playerStats.ts
@@ -1,5 +1,5 @@
 import { Player, Season, Tournament } from '@/types';
-import { AppState } from '@/app/page';
+import { AppState } from '@/types';
 
 // Define a type for the processed stats
 export interface PlayerStats {

--- a/src/utils/savedGames.test.ts
+++ b/src/utils/savedGames.test.ts
@@ -1,5 +1,5 @@
 import type { Player } from '@/types';
-// Import AppState and other necessary types from @/app/page
+// Import AppState and other necessary types from @/types
 import type { 
   AppState, 
   SavedGamesCollection, 
@@ -7,7 +7,7 @@ import type {
   // Point, // Removed unused import
   // Opponent, // Removed unused import
   // IntervalLog // Removed unused import
-} from '@/app/page';
+} from '@/types';
 import {
   getSavedGames,
   saveGames,
@@ -26,7 +26,7 @@ import {
   getLatestGameId,
   // GameData, // No longer importing GameData for test mocks, using AppState
 } from './savedGames';
-import { SAVED_GAMES_KEY } from '@/config/constants';
+import { SAVED_GAMES_KEY } from '@/config/storageKeys';
 
 // TestGameEvent is no longer needed, use PageGameEvent directly
 

--- a/src/utils/savedGames.ts
+++ b/src/utils/savedGames.ts
@@ -1,8 +1,9 @@
-import { SAVED_GAMES_KEY, DEFAULT_GAME_ID } from '@/config/constants';
-import type { SavedGamesCollection, AppState, GameEvent as PageGameEvent, Point, Opponent, IntervalLog } from '@/app/page';
+import { DEFAULT_GAME_ID } from '@/config/constants';
+import { SAVED_GAMES_KEY } from '@/config/storageKeys';
+import type { SavedGamesCollection, AppState, GameEvent as PageGameEvent, Point, Opponent, IntervalLog } from '@/types';
 import type { Player } from '@/types';
 
-// Note: AppState (imported from @/app/page) is the primary type used for live game state
+// Note: AppState (imported from @/types) is the primary type used for live game state
 // and for storing games in localStorage via SavedGamesCollection.
 // This GameData interface may represent a legacy structure or a specific format for other operations (e.g., import/export).
 // Define GameData interface more precisely

--- a/src/utils/seasons.test.ts
+++ b/src/utils/seasons.test.ts
@@ -1,4 +1,4 @@
-import { SEASONS_LIST_KEY } from '@/config/constants';
+import { SEASONS_LIST_KEY } from '@/config/storageKeys';
 import { getSeasons, saveSeasons, addSeason, updateSeason, deleteSeason } from './seasons'; // Adjust path as needed
 import type { Season } from '@/types'; // Import Season type directly from types
 

--- a/src/utils/seasons.ts
+++ b/src/utils/seasons.ts
@@ -1,4 +1,4 @@
-import { SEASONS_LIST_KEY } from '@/config/constants';
+import { SEASONS_LIST_KEY } from '@/config/storageKeys';
 import type { Season } from '@/types'; // Import Season type from shared types
 
 // Define the Season type (consider moving to a shared types file if not already there)

--- a/src/utils/tournaments.test.ts
+++ b/src/utils/tournaments.test.ts
@@ -1,4 +1,4 @@
-import { TOURNAMENTS_LIST_KEY } from '@/config/constants';
+import { TOURNAMENTS_LIST_KEY } from '@/config/storageKeys';
 import { 
   getTournaments, 
   addTournament, 

--- a/src/utils/tournaments.ts
+++ b/src/utils/tournaments.ts
@@ -1,4 +1,4 @@
-import { TOURNAMENTS_LIST_KEY } from '@/config/constants';
+import { TOURNAMENTS_LIST_KEY } from '@/config/storageKeys';
 import type { Tournament } from '@/types'; // Import Tournament type from shared types
 
 // Define the Tournament type (consider moving to a shared types file)


### PR DESCRIPTION
## Summary
- move game-related interfaces to src/types/game.ts
- export new types from src/types/index.ts
- centralize localStorage keys in src/config/storageKeys.ts
- update imports across app and tests
- add jest test ensuring modules resolve

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules and test type errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aec06abc0832cb72764daa0055f7f