### PR TITLE
Implement modal context provider

### DIFF
--- a/.docs/page-refactor-plan.md
+++ b/.docs/page-refactor-plan.md
@@ -156,6 +156,12 @@
 **Unit tests**
 - Mount a test component inside the provider, toggle a modal and assert context value updates.
 
+### Manual testing
+- Launch the app and open each modal from the control bar to verify it appears and closes correctly.
+- Open different modals in succession to ensure they do not interfere with each other's visibility.
+- Refresh the page and confirm all modals are closed on initial load.
+- Perform common actions like saving or loading a game to ensure the related modal still functions.
+
 ---
 
 ## 9. Collapse **Derived Data & Selectors**
@@ -212,7 +218,7 @@ Remove obsolete code and make sure the line-count drops below ~300 lines.
 4. PR-4 – Step 4 (timer)
 5. PR-5 – Step 5 (tactical board)
 6. PR-6 – Step 6 (roster)
-7. PR-7 – Step 7 (export utils)
+7. PR-7 – Step 7 (export utils) ✅
 8. PR-8 – Step 8 (modal context)
 9. PR-9 – Step 9 & 10 sweep
 10. PR-10 – Docs & clean-up

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -48,6 +48,7 @@ import { useGameDataQueries } from '@/hooks/useGameDataQueries';
 import { useUndoRedo } from '@/hooks/useUndoRedo';
 import { useTacticalBoard } from '@/hooks/useTacticalBoard';
 import { useRoster } from '@/hooks/useRoster';
+import ModalProvider, { useModalContext } from '@/contexts/ModalProvider';
 // Import async localStorage utilities
 import { getLocalStorageItemAsync, setLocalStorageItemAsync, removeLocalStorageItemAsync } from '@/utils/localStorage';
 // Import query keys
@@ -113,7 +114,7 @@ const initialState: AppState = {
 
 
 
-export default function Home() {
+function HomePage() {
   console.log('--- page.tsx RENDER ---');
   const { t } = useTranslation(); // Get translation function
   const queryClient = useQueryClient(); // Get query client instance
@@ -342,22 +343,33 @@ export default function Home() {
   // <<< ADD: State for home/away status >>>
   const [initialLoadComplete, setInitialLoadComplete] = useState<boolean>(false);
   const [hasSkippedInitialSetup, setHasSkippedInitialSetup] = useState<boolean>(false);
-  const [isGameSettingsModalOpen, setIsGameSettingsModalOpen] = useState<boolean>(false); // <<< ADDED State Declaration
-  const [isLoadGameModalOpen, setIsLoadGameModalOpen] = useState<boolean>(false);
-  const [isRosterModalOpen, setIsRosterModalOpen] = useState<boolean>(false); // State for the new modal
-  const [isSeasonTournamentModalOpen, setIsSeasonTournamentModalOpen] = useState<boolean>(false);
+  const {
+    isGameSettingsModalOpen,
+    setIsGameSettingsModalOpen,
+    isLoadGameModalOpen,
+    setIsLoadGameModalOpen,
+    isRosterModalOpen,
+    setIsRosterModalOpen,
+    isSeasonTournamentModalOpen,
+    setIsSeasonTournamentModalOpen,
+    isTrainingResourcesOpen,
+    setIsTrainingResourcesOpen,
+    isGoalLogModalOpen,
+    setIsGoalLogModalOpen,
+    isGameStatsModalOpen,
+    setIsGameStatsModalOpen,
+    isNewGameSetupModalOpen,
+    setIsNewGameSetupModalOpen,
+    isSaveGameModalOpen,
+    setIsSaveGameModalOpen,
+  } = useModalContext();
   // const [isPlayerStatsModalOpen, setIsPlayerStatsModalOpen] = useState(false);
   const [selectedPlayerForStats, setSelectedPlayerForStats] = useState<Player | null>(null);
 
   // --- Timer State (Still needed here) ---
   const [showLargeTimerOverlay, setShowLargeTimerOverlay] = useState<boolean>(false); // State for overlay visibility
   
-  // --- Modal States (Still needed here) ---
-  const [isTrainingResourcesOpen, setIsTrainingResourcesOpen] = useState<boolean>(false); 
-  const [isGoalLogModalOpen, setIsGoalLogModalOpen] = useState<boolean>(false); 
-  const [isGameStatsModalOpen, setIsGameStatsModalOpen] = useState<boolean>(false);
-  const [isNewGameSetupModalOpen, setIsNewGameSetupModalOpen] = useState<boolean>(false);
-  const [isSaveGameModalOpen, setIsSaveGameModalOpen] = useState<boolean>(false);
+  // --- Modal States handled via context ---
 
   // <<< ADD State to hold player IDs for the next new game >>>
   const [playerIdsForNewGame, setPlayerIdsForNewGame] = useState<string[] | null>(null);
@@ -2556,3 +2568,4 @@ export default function Home() {
     </main>
   );
 }
+export default function Home() { return (<ModalProvider><HomePage /></ModalProvider>); }

--- a/src/contexts/ModalProvider.tsx
+++ b/src/contexts/ModalProvider.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface ModalContextValue {
+  isGameSettingsModalOpen: boolean;
+  setIsGameSettingsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isLoadGameModalOpen: boolean;
+  setIsLoadGameModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isRosterModalOpen: boolean;
+  setIsRosterModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isSeasonTournamentModalOpen: boolean;
+  setIsSeasonTournamentModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isTrainingResourcesOpen: boolean;
+  setIsTrainingResourcesOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isGoalLogModalOpen: boolean;
+  setIsGoalLogModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isGameStatsModalOpen: boolean;
+  setIsGameStatsModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isNewGameSetupModalOpen: boolean;
+  setIsNewGameSetupModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  isSaveGameModalOpen: boolean;
+  setIsSaveGameModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const ModalContext = createContext<ModalContextValue | undefined>(undefined);
+
+export const ModalProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isGameSettingsModalOpen, setIsGameSettingsModalOpen] = useState(false);
+  const [isLoadGameModalOpen, setIsLoadGameModalOpen] = useState(false);
+  const [isRosterModalOpen, setIsRosterModalOpen] = useState(false);
+  const [isSeasonTournamentModalOpen, setIsSeasonTournamentModalOpen] = useState(false);
+  const [isTrainingResourcesOpen, setIsTrainingResourcesOpen] = useState(false);
+  const [isGoalLogModalOpen, setIsGoalLogModalOpen] = useState(false);
+  const [isGameStatsModalOpen, setIsGameStatsModalOpen] = useState(false);
+  const [isNewGameSetupModalOpen, setIsNewGameSetupModalOpen] = useState(false);
+  const [isSaveGameModalOpen, setIsSaveGameModalOpen] = useState(false);
+
+  const value: ModalContextValue = {
+    isGameSettingsModalOpen,
+    setIsGameSettingsModalOpen,
+    isLoadGameModalOpen,
+    setIsLoadGameModalOpen,
+    isRosterModalOpen,
+    setIsRosterModalOpen,
+    isSeasonTournamentModalOpen,
+    setIsSeasonTournamentModalOpen,
+    isTrainingResourcesOpen,
+    setIsTrainingResourcesOpen,
+    isGoalLogModalOpen,
+    setIsGoalLogModalOpen,
+    isGameStatsModalOpen,
+    setIsGameStatsModalOpen,
+    isNewGameSetupModalOpen,
+    setIsNewGameSetupModalOpen,
+    isSaveGameModalOpen,
+    setIsSaveGameModalOpen,
+  };
+
+  return <ModalContext.Provider value={value}>{children}</ModalContext.Provider>;
+};
+
+export const useModalContext = () => {
+  const ctx = useContext(ModalContext);
+  if (!ctx) {
+    throw new Error('useModalContext must be used within ModalProvider');
+  }
+  return ctx;
+};
+
+export default ModalProvider;

--- a/src/contexts/__tests__/ModalProvider.test.tsx
+++ b/src/contexts/__tests__/ModalProvider.test.tsx
@@ -1,0 +1,16 @@
+import { renderHook, act } from '@testing-library/react';
+import { ModalProvider, useModalContext } from '../ModalProvider';
+import React from 'react';
+
+test('modal context toggles state', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ModalProvider>{children}</ModalProvider>
+  );
+  const { result } = renderHook(() => useModalContext(), { wrapper });
+
+  act(() => {
+    result.current.setIsGameSettingsModalOpen(true);
+  });
+
+  expect(result.current.isGameSettingsModalOpen).toBe(true);
+});


### PR DESCRIPTION
## Summary
- confirm completion of export utility step in refactor plan and note PR step
- add manual testing checklist for modal context step
- introduce `ModalProvider` context and related unit test
- update `page.tsx` to consume modal context and wrap with provider

## Testing
- `npx jest --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686cc1e368a0832c9ade836a0d699ccc