### PR TITLE
Fix ESLint error in savedGames tests

### DIFF
--- a/src/utils/savedGames.test.ts
+++ b/src/utils/savedGames.test.ts
@@ -579,8 +579,8 @@ describe('Saved Games Utilities', () => {
     });
 
     it('should reject if a game fails validation', async () => {
-      const invalidGame: Record<string, unknown> = { ...mockGame2_AppState };
-      delete invalidGame.teamName; // required field missing
+      const invalidGame = { ...mockGame2_AppState } as Record<string, unknown>;
+      delete invalidGame.teamName; // remove required field
       const gamesToImport: SavedGamesCollection = {
         invalid: invalidGame as unknown as AppState,
       };


### PR DESCRIPTION
## Summary
- remove use of `any` in `savedGames.test.ts`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d0a0c5f08832c8c8aa16a454e4850