### PR TITLE
Implement quick-save toast and logging utility

### DIFF
--- a/.docs/deep-code-review-tasks.md
+++ b/.docs/deep-code-review-tasks.md
@@ -37,14 +37,34 @@ Manual verification after implementing the above:
 - [x] `useGameTimer` recreates its interval every second because `timeElapsedInSeconds` is in the dependency list. Refactor to keep a stable interval while running, using a ref for the latest state.
 - [x] Consider moving the `formatTime` helper from `TimerOverlay.tsx` to a shared utility module.
 
+Manual verification after implementing the above:
+  1. Start a new game and ensure the timer counts smoothly without resetting every second.
+  2. Pause and resume play and verify the timer resumes from the correct elapsed time.
+  3. Let the timer reach the end of a period and confirm it stops and advances the game state correctly.
+  4. Reload the page while a period is running and confirm the timer state restores from localStorage.
+
 ## 5. User Feedback & Logging
-- [ ] Provide visual confirmation when the quick‑save operation succeeds (the TODO near line 1782 of `HomePage.tsx`). A toast notification is sufficient.
-- [ ] Replace verbose `console.log` statements with a lightweight logging utility that can be disabled in production builds.
+- [x] Provide visual confirmation when the quick‑save operation succeeds (the TODO near line 1782 of `HomePage.tsx`). A toast notification is sufficient.
+- [x] Replace verbose `console.log` statements with a lightweight logging utility that can be disabled in production builds.
+
+Manual verification after implementing the above:
+  1. Perform a quick save and verify a green toast briefly appears confirming success.
+  2. Disable localStorage to force a quick save error and confirm an alert is shown and the error is logged.
+  3. Open the browser console in development and ensure log messages appear via the logger utility.
+  4. Build the project for production and confirm informational logs no longer appear in the console.
 
 ## 6. Translation Maintenance
 - [ ] The custom augmentations in `src/i18n.ts` complicate merging JSON locale files. Investigate generating type definitions for translation keys and consolidating all translations in JSON to avoid runtime mutations.
 
+Manual verification after implementing the above:
+  1. Run the type generation script and verify `tsc` passes with the generated definitions.
+  2. Switch languages in the app and confirm all strings render correctly without runtime warnings.
+
 ## 7. Additional Testing
 - [ ] Extend unit tests for `useGameSessionReducer` to cover score adjustment and timer reset edge cases.
 - [ ] Add smoke tests for the modal context to ensure modals do not interfere with each other when opened sequentially.
+
+Manual verification after implementing the above:
+  1. Run all Jest suites and ensure new reducer tests pass.
+  2. Manually open and close each modal in succession to confirm they do not overlap or freeze the UI.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ The app is designed to be an all-in-one digital assistant for game day, from pre
 *   **Data Storage:** All your data is stored in your browser's `localStorage`. This is fast and enables offline use, but it means clearing your browser data will erase everything. **Use the "Full Backup" feature regularly!**
 *   **Offline Use:** To get the best experience, install the app on your device when prompted by your browser ("Add to Home Screen" on mobile, or an install icon in the address bar on desktop).
 
+### Manual Testing Checklist
+
+1. Start the development server with `npm run dev` and perform a quick save from the home page. A green toast should appear confirming the save.
+2. Disable localStorage in your browser tools and attempt to save a game; an error should be logged but the app must not crash.
+3. Trigger the language switcher and verify all labels update without page reloads.
+4. Start the game timer and ensure it continues counting even when switching views or modals.
+5. Use the backup export feature and verify a file downloads with your saved games.
+
 ---
 
 *This project is under active development. Feel free to contribute or report issues!**

--- a/src/components/ClientWrapper.tsx
+++ b/src/components/ClientWrapper.tsx
@@ -4,17 +4,19 @@ import React from 'react';
 // Remove direct import of I18nextProvider and i18n instance
 // import { I18nextProvider } from 'react-i18next';
 // import i18n from '../i18n';
-import I18nInitializer from './I18nInitializer'; // Import the initializer component
-import InstallPrompt from './InstallPrompt'; // Import the InstallPrompt component
+import I18nInitializer from './I18nInitializer';
+import InstallPrompt from './InstallPrompt';
 import ServiceWorkerRegistration from './ServiceWorkerRegistration';
+import { ToastProvider } from '@/contexts/ToastProvider';
 
 const ClientWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   return (
-    // Use the I18nInitializer to handle waiting for translations
     <I18nInitializer>
-      <ServiceWorkerRegistration /> {/* Register the service worker */}
-      {children}
-      <InstallPrompt /> {/* Add the installation prompt */}
+      <ServiceWorkerRegistration />
+      <ToastProvider>
+        {children}
+        <InstallPrompt />
+      </ToastProvider>
     </I18nInitializer>
   );
 };

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -39,6 +39,7 @@ import { FaFutbol } from 'react-icons/fa';
 
 // Import translation hook
 import { useTranslation } from 'react-i18next';
+import logger from '@/utils/logger';
 
 // Define props for ControlBar
 interface ControlBarProps {
@@ -101,7 +102,7 @@ const ControlBar: React.FC<ControlBarProps> = ({
   onAddOpponentDisc,
 }) => {
   const { t, i18n } = useTranslation(); // Standard hook
-  console.log('[ControlBar Render] Received highlightRosterButton prop:', highlightRosterButton); // <<< Log prop value
+  logger.log('[ControlBar Render] Received highlightRosterButton prop:', highlightRosterButton); // <<< Log prop value
   const [isSettingsMenuOpen, setIsSettingsMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<'main' | 'tulospalvelu'>('main'); // NEW state for menu view
   const settingsMenuRef = useRef<HTMLDivElement>(null);
@@ -120,7 +121,7 @@ const ControlBar: React.FC<ControlBarProps> = ({
   const handleLanguageToggle = () => {
     const nextLang = i18n.language === 'en' ? 'fi' : 'en';
     i18n.changeLanguage(nextLang);
-    console.log(`Changed language to ${nextLang}`);
+    logger.log(`Changed language to ${nextLang}`);
     setIsSettingsMenuOpen(false); // Close menu after action
     setMenuView('main'); 
   };

--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import logger from '@/utils/logger';
 import { FaEdit, FaTrashAlt } from 'react-icons/fa';
 import { HiPlusCircle } from 'react-icons/hi2';
 import { Season, Tournament, Player } from '@/types';
@@ -141,7 +142,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
   timeElapsedInSeconds,
   updateGameDetailsMutation,
 }) => {
-  // console.log('[GameSettingsModal Render] Props received:', { seasonId, tournamentId, currentGameId });
+  // logger.log('[GameSettingsModal Render] Props received:', { seasonId, tournamentId, currentGameId });
   const { t } = useTranslation();
 
   // State for event editing within the modal
@@ -252,14 +253,14 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
           const loadedSeasonsData = await getSeasons();
           setSeasons(Array.isArray(loadedSeasonsData) ? loadedSeasonsData : []);
       } catch (error) {
-        console.error('Error loading seasons:', error);
+        logger.error('Error loading seasons:', error);
         setSeasons([]);
       }
       try {
           const loadedTournamentsData = await getTournaments();
           setTournaments(Array.isArray(loadedTournamentsData) ? loadedTournamentsData : []);
       } catch (error) {
-        console.error('Error loading tournaments:', error);
+        logger.error('Error loading tournaments:', error);
         setTournaments([]);
       }
       };
@@ -339,7 +340,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
   // Handle saving edited goal
   const handleSaveGoal = async (goalId: string) => {
     if (!goalId || !currentGameId) {
-      console.error("[GameSettingsModal] Missing goalId or currentGameId for save.");
+      logger.error("[GameSettingsModal] Missing goalId or currentGameId for save.");
       setError(t('gameSettingsModal.errors.missingGoalId', 'Goal ID or Game ID is missing. Cannot save.'));
       return;
     }
@@ -365,7 +366,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
 
     const originalEvent = localGameEvents.find(e => e.id === goalId);
     if (!originalEvent) {
-        console.error(`[GameSettingsModal] Original event not found for ID: ${goalId}`);
+        logger.error(`[GameSettingsModal] Original event not found for ID: ${goalId}`);
       return;
     }
 
@@ -387,20 +388,20 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
       if (eventIndex !== -1) {
         const success = await updateGameEvent(currentGameId, eventIndex, updatedEvent);
         if (success) {
-          console.log(`[GameSettingsModal] Event ${goalId} updated in game ${currentGameId}.`);
+          logger.log(`[GameSettingsModal] Event ${goalId} updated in game ${currentGameId}.`);
           handleCancelEditGoal(); // Close edit mode on success
         } else {
-          console.error(`[GameSettingsModal] Failed to update event ${goalId} in game ${currentGameId} via utility.`);
+          logger.error(`[GameSettingsModal] Failed to update event ${goalId} in game ${currentGameId} via utility.`);
           setError(t('gameSettingsModal.errors.updateFailed', 'Failed to update event. Please try again.'));
           // Optionally revert UI:
           // setLocalGameEvents(gameEvents); // Revert local state if save failed
         }
       } else {
-        console.error(`[GameSettingsModal] Event ${goalId} not found in original gameEvents prop for saving.`);
+        logger.error(`[GameSettingsModal] Event ${goalId} not found in original gameEvents prop for saving.`);
         setError(t('gameSettingsModal.errors.eventNotFound', 'Original event not found for saving.'));
       }
     } catch (err) {
-      console.error(`[GameSettingsModal] Error updating event ${goalId} in game ${currentGameId}:`, err);
+      logger.error(`[GameSettingsModal] Error updating event ${goalId} in game ${currentGameId}:`, err);
       setError(t('gameSettingsModal.errors.genericSaveError', 'An unexpected error occurred while saving the event.'));
       // Optionally revert UI:
       // setLocalGameEvents(gameEvents); // Revert local state if save failed
@@ -414,7 +415,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
   // Handle deleting a goal
   const handleDeleteGoal = async (goalId: string) => {
     if (!onDeleteGameEvent || !currentGameId) {
-      console.error("[GameSettingsModal] Missing onDeleteGameEvent handler or currentGameId for delete.");
+      logger.error("[GameSettingsModal] Missing onDeleteGameEvent handler or currentGameId for delete.");
       setError(t('gameSettingsModal.errors.missingDeleteHandler', 'Cannot delete event: Critical configuration missing.'));
       return;
     }
@@ -425,7 +426,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
       try {
         const eventIndex = gameEvents.findIndex(e => e.id === goalId); 
         if (eventIndex === -1) {
-          console.error(`[GameSettingsModal] Event ${goalId} not found in original gameEvents for deletion.`);
+          logger.error(`[GameSettingsModal] Event ${goalId} not found in original gameEvents for deletion.`);
           setError(t('gameSettingsModal.errors.eventNotFoundDelete', 'Event to delete not found.'));
           setIsProcessing(false); // Stop processing early
           return;
@@ -438,14 +439,14 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         
         const success = await removeGameEvent(currentGameId, eventIndex);
         if (success) {
-          console.log(`[GameSettingsModal] Event ${goalId} removed from game ${currentGameId}.`);
+          logger.log(`[GameSettingsModal] Event ${goalId} removed from game ${currentGameId}.`);
         } else {
-          console.error(`[GameSettingsModal] Failed to remove event ${goalId} from game ${currentGameId} via utility.`);
+          logger.error(`[GameSettingsModal] Failed to remove event ${goalId} from game ${currentGameId} via utility.`);
           setError(t('gameSettingsModal.errors.deleteFailed', 'Failed to delete event. Please try again.'));
           setLocalGameEvents(originalLocalEvents); // Revert local UI on failure
         }
       } catch (err) {
-        console.error(`[GameSettingsModal] Error removing event ${goalId} from game ${currentGameId}:`, err);
+        logger.error(`[GameSettingsModal] Error removing event ${goalId} from game ${currentGameId}:`, err);
         setError(t('gameSettingsModal.errors.genericDeleteError', 'An unexpected error occurred while deleting the event.'));
         // Consider reverting localGameEvents here as well if an error occurs
       } finally {
@@ -482,7 +483,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
 
     try {
       if (!currentGameId) {
-        console.error("[GameSettingsModal] currentGameId is null, cannot save inline edit.");
+        logger.error("[GameSettingsModal] currentGameId is null, cannot save inline edit.");
         setError(t('gameSettingsModal.errors.missingGameIdInline', "Cannot save: Game ID missing."));
         return;
       }
@@ -546,12 +547,12 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
           break;
       }
       if (success) {
-        console.log(`[GameSettingsModal] Inline edit for ${fieldProcessed} saved for game ${currentGameId}.`);
+        logger.log(`[GameSettingsModal] Inline edit for ${fieldProcessed} saved for game ${currentGameId}.`);
         setInlineEditingField(null); // Exit inline edit mode on success
         setInlineEditValue('');
       }
     } catch (err) {
-      console.error(`[GameSettingsModal] Error saving inline edit for ${fieldProcessed} (Game ID: ${currentGameId}):`, err);
+      logger.error(`[GameSettingsModal] Error saving inline edit for ${fieldProcessed} (Game ID: ${currentGameId}):`, err);
       setError(t('gameSettingsModal.errors.genericInlineSaveError', "Error saving changes. Please try again."));
     } finally {
       setIsProcessing(false);
@@ -618,7 +619,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         setShowNewSeasonInput(false);
       }
     } catch (error) {
-      console.error("Error calling addSeasonMutation.mutateAsync:", error);
+      logger.error("Error calling addSeasonMutation.mutateAsync:", error);
       newSeasonInputRef.current?.focus();
     }
   };
@@ -642,7 +643,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         setShowNewTournamentInput(false);
       }
     } catch (error) {
-      console.error("Error calling addTournamentMutation.mutateAsync:", error);
+      logger.error("Error calling addTournamentMutation.mutateAsync:", error);
       newTournamentInputRef.current?.focus();
     }
   };

--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import logger from '@/utils/logger';
 // Import types from the types directory
 import { Player, PlayerStatRow, Season, Tournament } from '@/types';
 import { GameEvent, SavedGamesCollection } from '@/types';
@@ -111,7 +112,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
   gameEvents,
   gameNotes = '',
   onGameNotesChange = () => {},
-  onUpdateGameEvent = () => { /* console.warn('onUpdateGameEvent handler not provided'); */ },
+  onUpdateGameEvent = () => { /* logger.warn('onUpdateGameEvent handler not provided'); */ },
   selectedPlayerIds,
   savedGames, // Not actively used after removing aggregation
   currentGameId,
@@ -126,20 +127,20 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
   const { t, i18n } = useTranslation();
 
   // <<< ADD DIAGNOSTIC LOG >>>
-  // console.log('[GameStatsModal Render] gameEvents prop:', JSON.stringify(gameEvents));
-  // console.log('[GameStatsModal Render] availablePlayers prop ref check:', availablePlayers); // Log reference too
+  // logger.log('[GameStatsModal Render] gameEvents prop:', JSON.stringify(gameEvents));
+  // logger.log('[GameStatsModal Render] availablePlayers prop ref check:', availablePlayers); // Log reference too
 
   // REVISED formatDisplayDate definition without date-fns
   const formatDisplayDate = useCallback((isoDate: string): string => {
     if (!isoDate) return t('common.notSet', 'Ei asetettu');
     try {
       if (isoDate.length !== 10) { // Basic check for YYYY-MM-DD format
-        // console.warn(`Invalid date format received: ${isoDate}`);
+        // logger.warn(`Invalid date format received: ${isoDate}`);
         return isoDate;
       }
       const date = new Date(isoDate); 
       if (isNaN(date.getTime())) {
-        // console.warn(`Invalid date value received: ${isoDate}`);
+        // logger.warn(`Invalid date value received: ${isoDate}`);
           return isoDate; 
       }
 
@@ -160,7 +161,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
         });
       }
     } catch {
-      // console.error("Error formatting date:", e);
+      // logger.error("Error formatting date:", e);
       return 'Date Error';
     }
   }, [i18n.language, t]); // Dependencies: language and t function
@@ -200,11 +201,11 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
 
   // ** Calculate initial winner ID using useMemo **
   const initialFairPlayWinnerId = useMemo(() => {
-      // console.log("[GameStatsModal:useMemo] Calculating initialFairPlayWinnerId. availablePlayers prop:", JSON.stringify(availablePlayers.map(p => ({id: p.id, name: p.name, fp: p.receivedFairPlayCard}))));
+      // logger.log("[GameStatsModal:useMemo] Calculating initialFairPlayWinnerId. availablePlayers prop:", JSON.stringify(availablePlayers.map(p => ({id: p.id, name: p.name, fp: p.receivedFairPlayCard}))));
       const winner = availablePlayers.find(p => p.receivedFairPlayCard);
-      // console.log("[GameStatsModal:useMemo] Found winner object:", winner);
+      // logger.log("[GameStatsModal:useMemo] Found winner object:", winner);
       const winnerId = winner?.id || null;
-      // console.log("[GameStatsModal:useMemo] Determined initialFairPlayWinnerId:", winnerId);
+      // logger.log("[GameStatsModal:useMemo] Determined initialFairPlayWinnerId:", winnerId);
       return winnerId;
   }, [availablePlayers]);
 
@@ -217,13 +218,13 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
           const loadedSeasons = await utilGetSeasons(); 
         setSeasons(loadedSeasons);
         } catch (error) { 
-          console.error("Failed to load seasons:", error); setSeasons([]); 
+          logger.error("Failed to load seasons:", error); setSeasons([]); 
         }
       try {
           const loadedTournaments = await utilGetTournaments(); // Await the async call
         setTournaments(loadedTournaments);
         } catch (error) { 
-          console.error("Failed to load tournaments:", error); setTournaments([]); 
+          logger.error("Failed to load tournaments:", error); setTournaments([]); 
     }
       }
     };
@@ -269,7 +270,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
 
   // ** ADD Separate Effect to Sync local state with calculated initial ID **
   useEffect(() => {
-      // console.log("[GameStatsModal:useEffectSync] Syncing localFairPlayPlayerId. Current local:", localFairPlayPlayerId, "New initial:", initialFairPlayWinnerId);
+      // logger.log("[GameStatsModal:useEffectSync] Syncing localFairPlayPlayerId. Current local:", localFairPlayPlayerId, "New initial:", initialFairPlayWinnerId);
       setLocalFairPlayPlayerId(initialFairPlayWinnerId);
   }, [initialFairPlayWinnerId, localFairPlayPlayerId]);
 
@@ -603,7 +604,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
 
   // Modify filteredAndSortedPlayerStats useMemo to also return the list of game IDs processed
   const { stats: playerStats, gameIds: processedGameIds } = useMemo(() => {
-    // console.log("Recalculating player stats...", { activeTab, filterText, selectedSeasonIdFilter, selectedTournamentIdFilter, gameEvents: activeTab === 'currentGame' ? gameEvents : null, savedGames: activeTab !== 'currentGame' ? savedGames : null });
+    // logger.log("Recalculating player stats...", { activeTab, filterText, selectedSeasonIdFilter, selectedTournamentIdFilter, gameEvents: activeTab === 'currentGame' ? gameEvents : null, savedGames: activeTab !== 'currentGame' ? savedGames : null });
 
     // Initialize stats map - MODIFIED: Initialize differently based on tab
     const statsMap: { [key: string]: PlayerStatRow } = {};
@@ -855,9 +856,9 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
       if (onDeleteGameEvent && typeof onDeleteGameEvent === 'function') { 
         onDeleteGameEvent!(goalId); // ADD non-null assertion (!)
         setLocalGameEvents(prevEvents => prevEvents.filter(event => event.id !== goalId));
-        // console.log(`Locally deleted event ${goalId} and called parent handler.`);
+        // logger.log(`Locally deleted event ${goalId} and called parent handler.`);
         } else {
-        // console.warn("Delete handler (onDeleteGameEvent) not available or not a function.");
+        // logger.warn("Delete handler (onDeleteGameEvent) not available or not a function.");
       }
     }
   };

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import styles from './InstallPrompt.module.css';
+import logger from '@/utils/logger';
 
 // Define proper interfaces for better type safety
 interface BeforeInstallPromptEvent extends Event {
@@ -74,14 +75,14 @@ const InstallPrompt: React.FC = () => {
       const choiceResult = await installPrompt.userChoice;
       
       if (choiceResult.outcome === 'accepted') {
-        console.log('User accepted the install prompt');
+        logger.log('User accepted the install prompt');
       } else {
-        console.log('User dismissed the install prompt');
+        logger.log('User dismissed the install prompt');
         // Store the time when dismissed to avoid showing it again too soon
         localStorage.setItem('installPromptDismissed', Date.now().toString());
       }
     } catch (error) {
-      console.error('Error showing install prompt:', error);
+      logger.error('Error showing install prompt:', error);
     }
 
     setInstallPrompt(null);

--- a/src/components/LoadGameModal.tsx
+++ b/src/components/LoadGameModal.tsx
@@ -4,8 +4,9 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { SavedGamesCollection } from '@/types'; // Keep this if SavedGamesCollection is from here
 import { Season, Tournament } from '@/types'; // Corrected import path
+import logger from '@/utils/logger';
 import { 
-  HiOutlineDocumentArrowDown, 
+  HiOutlineDocumentArrowDown,
   HiOutlineEllipsisVertical,
   HiOutlineTrash,
   HiOutlineDocumentText,
@@ -84,14 +85,14 @@ const LoadGameModal: React.FC<LoadGameModalProps> = ({
           const loadedSeasonsData = await utilGetSeasons();
           setSeasons(Array.isArray(loadedSeasonsData) ? loadedSeasonsData : []);
         } catch (error) {
-        console.error("Error loading seasons via utility:", error);
+        logger.error("Error loading seasons via utility:", error);
         setSeasons([]); 
       }
       try {
           const loadedTournamentsData = await utilGetTournaments();
           setTournaments(Array.isArray(loadedTournamentsData) ? loadedTournamentsData : []);
         } catch (error) {
-        console.error("Error loading tournaments via utility:", error);
+        logger.error("Error loading tournaments via utility:", error);
         setTournaments([]);
       }
       };
@@ -163,7 +164,7 @@ const LoadGameModal: React.FC<LoadGameModalProps> = ({
           return timestampB - timestampA;
         }
       } catch (error) {
-        console.warn("Could not parse timestamps from game IDs for secondary sort:", a, b, error);
+        logger.warn("Could not parse timestamps from game IDs for secondary sort:", a, b, error);
       }
       
       // Fallback if dates are equal and timestamps can't be parsed

--- a/src/components/NewGameSetupModal.tsx
+++ b/src/components/NewGameSetupModal.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Player, Season, Tournament } from '@/types';
 import { HiPlusCircle } from 'react-icons/hi';
+import logger from '@/utils/logger';
 import { getSeasons as utilGetSeasons } from '@/utils/seasons';
 import { getTournaments as utilGetTournaments } from '@/utils/tournaments';
 import { getMasterRoster } from '@/utils/masterRosterManager';
@@ -131,7 +132,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
           // MOVED Focus to run earlier, but can be adjusted if data loading causes issues with it.
           // setTimeout(() => nameInputRef.current?.focus(), 100); 
         } catch (err) {
-          console.error("[NewGameSetupModal] Error fetching initial data:", err);
+          logger.error("[NewGameSetupModal] Error fetching initial data:", err);
           setError(t('newGameSetupModal.errors.dataLoadFailed', 'Failed to load initial setup data. Please try again.'));
           setHomeTeamName(t('newGameSetupModal.defaultTeamName', 'My Team'));
           setSeasons([]);
@@ -216,17 +217,17 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
         setSelectedTournamentId(null);
         setNewSeasonName(''); 
         setShowNewSeasonInput(false); 
-        console.log("Add season mutation initiated for:", newSeason.name);
+        logger.log("Add season mutation initiated for:", newSeason.name);
         // No need to manually update 'seasons' state here if page.tsx invalidates
       } else {
         // This block might be reached if mutateAsync resolves but utilAddSeason returned null (e.g., duplicate)
         // The mutation's onSuccess/onError in page.tsx would have more context.
-        console.warn("addSeasonMutation.mutateAsync completed, but newSeason is null. Check mutation's onSuccess/onError for details.");
+        logger.warn("addSeasonMutation.mutateAsync completed, but newSeason is null. Check mutation's onSuccess/onError for details.");
         // alert for duplicate is better handled by the mutation's error/success reporting if it returns a specific error or null for it
       }
     } catch (error) {
       // This catch is for errors from mutateAsync itself, if not handled by mutation's onError
-      console.error("Error calling addSeasonMutation.mutateAsync:", error);
+      logger.error("Error calling addSeasonMutation.mutateAsync:", error);
       // alert(t('newGameSetupModal.errorAddingSeasonGeneric', 'Error initiating add season. See console.'));
       // The actual user-facing error for mutation failure should come from the mutation's onError handler in page.tsx
       newSeasonInputRef.current?.focus();
@@ -252,13 +253,13 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
         setSelectedSeasonId(null); 
         setNewTournamentName(''); 
         setShowNewTournamentInput(false); 
-        console.log("Add tournament mutation initiated for:", newTournament.name);
+        logger.log("Add tournament mutation initiated for:", newTournament.name);
         // No need to manually update 'tournaments' state here
       } else {
-        console.warn("addTournamentMutation.mutateAsync completed, but newTournament is null.");
+        logger.warn("addTournamentMutation.mutateAsync completed, but newTournament is null.");
       }
     } catch (error) {
-      console.error("Error calling addTournamentMutation.mutateAsync:", error);
+      logger.error("Error calling addTournamentMutation.mutateAsync:", error);
       // alert(t('newGameSetupModal.errorAddingTournamentGeneric', 'Error initiating add tournament. See console.'));
       newTournamentInputRef.current?.focus();
     }
@@ -310,7 +311,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
     try {
       await utilSaveLastHomeTeamName(trimmedHomeTeamName);
     } catch (error) {
-      console.error("Failed to save last home team name:", error);
+      logger.error("Failed to save last home team name:", error);
       // Continue without blocking, as this is not critical for starting the game
     }
     // --- End Save ---

--- a/src/components/RosterSettingsModal.tsx
+++ b/src/components/RosterSettingsModal.tsx
@@ -10,6 +10,7 @@ import {
     HiOutlineChartBar
 } from 'react-icons/hi2';
 import { useTranslation } from 'react-i18next';
+import logger from '@/utils/logger';
 
 interface RosterSettingsModalProps {
   isOpen: boolean;
@@ -98,7 +99,7 @@ const RosterSettingsModal: React.FC<RosterSettingsModalProps> = ({
     // Find the player data directly from the current prop state INSIDE the handler
     const playerToEdit = availablePlayers.find(p => p.id === playerId);
     if (!playerToEdit) {
-      console.error("Player not found in availablePlayers for editing:", playerId);
+      logger.error("Player not found in availablePlayers for editing:", playerId);
       return; // Player not found, shouldn't happen
     }
 

--- a/src/components/SaveGameModal.tsx
+++ b/src/components/SaveGameModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import logger from '@/utils/logger';
 
 // REMOVED GameType definition as it's no longer used here
 // export type GameType = 'season' | 'tournament'; 
@@ -59,7 +60,7 @@ const SaveGameModal: React.FC<SaveGameModalProps> = ({
       onSave(trimmedName); 
       onClose(); 
     } else {
-      console.warn("Game name cannot be empty.");
+      logger.warn("Game name cannot be empty.");
       inputRef.current?.focus(); 
     }
   };

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import UpdateBanner from './UpdateBanner'; // Import the new component
+import logger from '@/utils/logger';
 
 export default function ServiceWorkerRegistration() {
   const [waitingWorker, setWaitingWorker] = useState<ServiceWorker | null>(null);
@@ -9,14 +10,14 @@ export default function ServiceWorkerRegistration() {
 
   useEffect(() => {
     if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
-      console.log('[PWA] Service Worker is not supported or not in browser.');
+      logger.log('[PWA] Service Worker is not supported or not in browser.');
       return;
     }
 
     const swUrl = '/sw.js';
 
     navigator.serviceWorker.register(swUrl).then(registration => {
-      console.log('[PWA] Service Worker registered: ', registration);
+      logger.log('[PWA] Service Worker registered: ', registration);
 
       // Look for a waiting service worker
       if (registration.waiting) {
@@ -28,10 +29,10 @@ export default function ServiceWorkerRegistration() {
       // Listen for updates
       registration.onupdatefound = () => {
         const newWorker = registration.installing;
-        console.log('[PWA] New service worker found:', newWorker);
+        logger.log('[PWA] New service worker found:', newWorker);
         if (newWorker) {
           newWorker.onstatechange = () => {
-            console.log('[PWA] New service worker state changed:', newWorker.state);
+            logger.log('[PWA] New service worker state changed:', newWorker.state);
             // When the new worker is installed and waiting
             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
               setWaitingWorker(newWorker);
@@ -41,7 +42,7 @@ export default function ServiceWorkerRegistration() {
         }
       };
     }).catch(error => {
-      console.error('[PWA] Service Worker registration failed: ', error);
+      logger.error('[PWA] Service Worker registration failed: ', error);
     });
 
     // Listen for controller changes
@@ -56,7 +57,7 @@ export default function ServiceWorkerRegistration() {
 
   const handleUpdate = () => {
     if (waitingWorker) {
-      console.log('[PWA] Posting message to waiting worker to skip waiting.');
+      logger.log('[PWA] Posting message to waiting worker to skip waiting.');
       waitingWorker.postMessage({ type: 'SKIP_WAITING' });
       setShowUpdateBanner(false);
     }

--- a/src/components/SoccerField.tsx
+++ b/src/components/SoccerField.tsx
@@ -4,6 +4,7 @@ import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { Player } from '@/types'; // Import Player from types
 import { Point, Opponent, TacticalDisc } from '@/types'; // Import Point and Opponent from page
 import tinycolor from 'tinycolor2';
+import logger from '@/utils/logger';
 
 // Define props for SoccerField
 interface SoccerFieldProps {
@@ -159,7 +160,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
 
     // *** SAFETY CHECK: Ensure calculated CSS dimensions are valid ***
     if (W <= 0 || H <= 0 || !Number.isFinite(W) || !Number.isFinite(H)) {
-      console.warn("Canvas dimensions are invalid, skipping draw:", { W, H });
+      logger.warn("Canvas dimensions are invalid, skipping draw:", { W, H });
       return; 
     }
 
@@ -335,7 +336,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
       const startX = path[0].relX * W;
       const startY = path[0].relY * H;
       if (!Number.isFinite(startX) || !Number.isFinite(startY)) {
-        console.warn("Skipping drawing path due to non-finite start point", path[0]);
+        logger.warn("Skipping drawing path due to non-finite start point", path[0]);
         return; 
       }
 
@@ -346,7 +347,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
         const pointX = path[i].relX * W;
         const pointY = path[i].relY * H;
         if (!Number.isFinite(pointX) || !Number.isFinite(pointY)) {
-          console.warn("Skipping drawing segment due to non-finite point", path[i]);
+          logger.warn("Skipping drawing segment due to non-finite point", path[i]);
           context.stroke(); 
           context.beginPath();
           context.moveTo(pointX, pointY);
@@ -363,14 +364,14 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
     if (!isTacticsBoardView) {
     opponents.forEach(opponent => {
       if (typeof opponent.relX !== 'number' || typeof opponent.relY !== 'number') {
-        console.warn("Skipping opponent due to invalid relX/relY", opponent);
+        logger.warn("Skipping opponent due to invalid relX/relY", opponent);
         return;
       }
       // Calculate absolute positions using CSS dimensions (W/H)
       const absX = opponent.relX * W;
       const absY = opponent.relY * H;
       if (!Number.isFinite(absX) || !Number.isFinite(absY)) {
-        console.warn("Skipping opponent due to non-finite calculated position", { opponent, absX, absY });
+        logger.warn("Skipping opponent due to non-finite calculated position", { opponent, absX, absY });
         return;
       }
 
@@ -425,7 +426,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
         const absX = disc.relX * W;
         const absY = disc.relY * H;
         if (!Number.isFinite(absX) || !Number.isFinite(absY)) {
-          console.warn("Skipping tactical disc due to non-finite calculated position", { disc, absX, absY });
+          logger.warn("Skipping tactical disc due to non-finite calculated position", { disc, absX, absY });
           return;
         }
 
@@ -498,7 +499,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
       const absX = player.relX * W;
       const absY = player.relY * H;
       if (!Number.isFinite(absX) || !Number.isFinite(absY)) {
-        console.warn("Skipping player due to non-finite calculated position", { player, absX, absY });
+        logger.warn("Skipping player due to non-finite calculated position", { player, absX, absY });
         return;
       }
 
@@ -580,7 +581,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
     const parent = canvas?.parentElement; // Observe the parent which dictates size
     if (!parent || typeof ResizeObserver === 'undefined') {
         // Fallback or handle browsers without ResizeObserver
-        console.warn('ResizeObserver not supported or parent not found');
+        logger.warn('ResizeObserver not supported or parent not found');
         // Consider adding back the window resize listener as a fallback?
         draw(); // Initial draw attempt
         return; 
@@ -639,7 +640,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
 
     // Check for invalid dimensions before calculating relative position
     if (rect.width <= 0 || rect.height <= 0) {
-        console.warn("Canvas has invalid dimensions, cannot calculate relative position.");
+        logger.warn("Canvas has invalid dimensions, cannot calculate relative position.");
         return null;
     }
 
@@ -755,7 +756,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
     } else {
     // *** Check if placing a tapped player ***
     if (draggingPlayerFromBarInfo) {
-      console.log("Field MouseDown: Placing player from bar tap:", draggingPlayerFromBarInfo.id);
+      logger.log("Field MouseDown: Placing player from bar tap:", draggingPlayerFromBarInfo.id);
       onPlayerDrop(draggingPlayerFromBarInfo.id, relPos.relX, relPos.relY);
       // IMPORTANT: Clear the selection state after placing
       // This needs to happen in the parent (page.tsx), 
@@ -889,7 +890,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
 
     // *** Check if placing a tapped player ***
     if (draggingPlayerFromBarInfo) {
-        console.log("Field TouchStart: Placing player from bar tap:", draggingPlayerFromBarInfo.id);
+        logger.log("Field TouchStart: Placing player from bar tap:", draggingPlayerFromBarInfo.id);
         // Don't preventDefault here for placing, allow potential scroll if placement fails
         onPlayerDropViaTouch(relPos.relX, relPos.relY);
         setActiveTouchId(null); 
@@ -1070,7 +1071,7 @@ const SoccerField: React.FC<SoccerFieldProps> = ({
         const parsedData = JSON.parse(data);
         droppedPlayerId = parsedData.id;
         if (!droppedPlayerId) throw new Error("ID missing");
-    } catch (error) { console.error("Drop data error:", error); return; }
+    } catch (error) { logger.error("Drop data error:", error); return; }
 
     const canvas = canvasRef.current;
     if (!canvas) return;

--- a/src/components/TimerOverlay.tsx
+++ b/src/components/TimerOverlay.tsx
@@ -5,6 +5,7 @@ import { FaPlay, FaPause, FaUndo } from 'react-icons/fa'; // Import icons
 import { useTranslation } from 'react-i18next'; // Import translation hook
 import { IntervalLog } from '@/types'; // Import the IntervalLog interface
 import { formatTime } from '@/utils/time';
+import logger from '@/utils/logger';
 
 
 interface TimerOverlayProps {
@@ -45,8 +46,8 @@ const TimerOverlay: React.FC<TimerOverlayProps> = ({
   isTimerRunning,
   onStartPauseTimer,
   onResetTimer,
-  onToggleGoalLogModal = () => { console.warn('onToggleGoalLogModal handler not provided'); },
-  onRecordOpponentGoal = () => { console.warn('onRecordOpponentGoal handler not provided'); },
+  onToggleGoalLogModal = () => { logger.warn('onToggleGoalLogModal handler not provided'); },
+  onRecordOpponentGoal = () => { logger.warn('onRecordOpponentGoal handler not provided'); },
   teamName = "Team",
   opponentName = "Opponent",
   homeScore = 0,
@@ -58,7 +59,7 @@ const TimerOverlay: React.FC<TimerOverlayProps> = ({
   currentPeriod = 1,
   gameStatus = 'notStarted',
   lastSubTime = null,
-  onOpponentNameChange = () => { console.warn('onOpponentNameChange handler not provided'); },
+  onOpponentNameChange = () => { logger.warn('onOpponentNameChange handler not provided'); },
   onClose,
   isLoaded,
 }) => {

--- a/src/contexts/ToastProvider.tsx
+++ b/src/contexts/ToastProvider.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface Toast {
+  id: number;
+  message: string;
+}
+
+interface ToastContextValue {
+  showToast: (message: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = (message: string) => {
+    const id = Date.now();
+    setToasts((prev) => [...prev, { id, message }]);
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div className="fixed top-4 right-4 space-y-2 z-50">
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            className="bg-green-600 text-white px-4 py-2 rounded shadow"
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within ToastProvider');
+  }
+  return ctx;
+};
+
+export default ToastProvider;

--- a/src/contexts/__tests__/ToastProvider.test.tsx
+++ b/src/contexts/__tests__/ToastProvider.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import { ToastProvider, useToast } from '../ToastProvider';
+
+const TestComponent = () => {
+  const { showToast } = useToast();
+  return <button onClick={() => showToast('Saved!')}>Trigger</button>;
+};
+
+test('showToast displays and hides a toast message', () => {
+  jest.useFakeTimers();
+  render(
+    <ToastProvider>
+      <TestComponent />
+    </ToastProvider>
+  );
+
+  fireEvent.click(screen.getByText('Trigger'));
+  expect(screen.getByText('Saved!')).toBeInTheDocument();
+
+  act(() => {
+    jest.advanceTimersByTime(3000);
+  });
+
+  expect(screen.queryByText('Saved!')).not.toBeInTheDocument();
+});

--- a/src/hooks/useGameSessionReducer.ts
+++ b/src/hooks/useGameSessionReducer.ts
@@ -1,4 +1,5 @@
-import { GameEvent } from '@/types'; // Assuming AppState might be useful context
+import { GameEvent } from '@/types';
+import logger from '@/utils/logger';
 
 // --- State Definition ---
 export interface GameSessionState {
@@ -116,7 +117,7 @@ export type GameSessionAction =
 
 // --- Reducer Function ---
 export const gameSessionReducer = (state: GameSessionState, action: GameSessionAction): GameSessionState => {
-  console.log('[gameSessionReducer] action type:', action.type);
+  logger.log('[gameSessionReducer] action type:', action.type);
   switch (action.type) {
     case 'LOAD_STATE_FROM_HISTORY':
     case 'LOAD_GAME_SESSION_STATE':
@@ -334,7 +335,7 @@ export const gameSessionReducer = (state: GameSessionState, action: GameSessionA
     case 'RESET_GAME_SESSION_STATE':
       return action.payload;
     case 'LOAD_PERSISTED_GAME_DATA': {
-      console.log('[gameSessionReducer] LOAD_PERSISTED_GAME_DATA - Received action.payload:', JSON.parse(JSON.stringify(action.payload)));
+      logger.log('[gameSessionReducer] LOAD_PERSISTED_GAME_DATA - Received action.payload:', JSON.parse(JSON.stringify(action.payload)));
       const loadedData = action.payload as Partial<GameSessionState>;
 
       const teamName = loadedData.teamName ?? initialGameSessionStatePlaceholder.teamName;
@@ -396,7 +397,7 @@ export const gameSessionReducer = (state: GameSessionState, action: GameSessionA
         subAlertLevel: 'none',
         lastSubConfirmationTimeSeconds: timeElapsedAtLoad,
       };
-      console.log('[gameSessionReducer] LOAD_PERSISTED_GAME_DATA - state to be returned:', JSON.parse(JSON.stringify(stateToBeReturned)));
+      logger.log('[gameSessionReducer] LOAD_PERSISTED_GAME_DATA - state to be returned:', JSON.parse(JSON.stringify(stateToBeReturned)));
       return stateToBeReturned;
     }
     default:

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -6,11 +6,12 @@ import {
     Point,
     AppState,
 } from '@/types'; // Reverted for Opponent, Point, AppState as they are likely still in page.tsx exports
-import { 
-    updatePlayer as updatePlayerInMasterRoster, 
+import {
+    updatePlayer as updatePlayerInMasterRoster,
     getMasterRoster as getMasterRosterFromManager,
     setGoalieStatus as setGoalieStatusInMasterRoster // Import setGoalieStatus
 } from '@/utils/masterRosterManager';
+import logger from '@/utils/logger';
 
 // Define arguments the hook will receive
 interface UseGameStateArgs {
@@ -57,7 +58,7 @@ export function useGameState({ initialState, saveStateToHistory }: UseGameStateA
 
     // Handler for dropping a player onto the field
     const handlePlayerDrop = useCallback((player: Player, position: { relX: number; relY: number }) => {
-        console.log(`Player ${player.name} dropped at`, position);
+        logger.log(`Player ${player.name} dropped at`, position);
         const newPlayerOnField: Player = {
             ...player,
             relX: position.relX,
@@ -142,7 +143,7 @@ export function useGameState({ initialState, saveStateToHistory }: UseGameStateA
 
     // Player Management Handlers (Moved here)
     const handleRenamePlayer = useCallback(async (playerId: string, playerData: { name: string; nickname: string }) => {
-        console.log(`[useGameState] handleRenamePlayer called for ID: ${playerId}, with data:`, playerData);
+        logger.log(`[useGameState] handleRenamePlayer called for ID: ${playerId}, with data:`, playerData);
         try {
             const updatedPlayerFromManager = await updatePlayerInMasterRoster(playerId, { 
                 name: playerData.name, 
@@ -164,21 +165,21 @@ export function useGameState({ initialState, saveStateToHistory }: UseGameStateA
             p.id === playerId ? { ...p, name: playerData.name, nickname: playerData.nickname } : p
                     )
                 });
-                console.log(`[useGameState] Player ${playerId} renamed to ${playerData.name}. Roster and field updated.`);
+                logger.log(`[useGameState] Player ${playerId} renamed to ${playerData.name}. Roster and field updated.`);
             } else {
-                console.error(`[useGameState] Failed to update player ${playerId} via masterRosterManager.`);
+                logger.error(`[useGameState] Failed to update player ${playerId} via masterRosterManager.`);
             }
         } catch (error) {
-            console.error(`[useGameState] Error in handleRenamePlayer for ID ${playerId}:`, error);
+            logger.error(`[useGameState] Error in handleRenamePlayer for ID ${playerId}:`, error);
         }
     }, [playersOnField, saveStateToHistory, setAvailablePlayers, setPlayersOnField]);
 
     // --- Add Goalie Handler Here ---
     const handleToggleGoalie = useCallback(async (playerId: string) => {
-        console.log(`[useGameState:handleToggleGoalie] Called for ${playerId}`);
+        logger.log(`[useGameState:handleToggleGoalie] Called for ${playerId}`);
         const playerToToggle = availablePlayers.find(p => p.id === playerId);
         if (!playerToToggle) {
-            console.error(`[useGameState:handleToggleGoalie] Player ${playerId} not found.`);
+            logger.error(`[useGameState:handleToggleGoalie] Player ${playerId} not found.`);
             return;
         }
         const targetGoalieStatus = !(playerToToggle.isGoalie ?? false);
@@ -203,12 +204,12 @@ export function useGameState({ initialState, saveStateToHistory }: UseGameStateA
                 // Save history for playersOnField change using the computed state
                 saveStateToHistory({ playersOnField: newPlayersOnFieldState });
     
-                console.log(`[useGameState:handleToggleGoalie] Goalie status for ${playerId} to ${targetGoalieStatus}. Roster and field updated.`);
+                logger.log(`[useGameState:handleToggleGoalie] Goalie status for ${playerId} to ${targetGoalieStatus}. Roster and field updated.`);
             } else {
-                console.error(`[useGameState:handleToggleGoalie] Failed to update goalie status for ${playerId} via masterRosterManager.`);
+                logger.error(`[useGameState:handleToggleGoalie] Failed to update goalie status for ${playerId} via masterRosterManager.`);
             }
         } catch (error) {
-            console.error(`[useGameState:handleToggleGoalie] Error toggling goalie for ID ${playerId}:`, error);
+            logger.error(`[useGameState:handleToggleGoalie] Error toggling goalie for ID ${playerId}:`, error);
         }
     }, [availablePlayers, saveStateToHistory, setAvailablePlayers, setPlayersOnField]);
 

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import logger from '@/utils/logger';
 
 export const useWakeLock = () => {
   const [wakeLock, setWakeLock] = useState<WakeLockSentinel | null>(null);
@@ -9,7 +10,7 @@ export const useWakeLock = () => {
     const supported = 'wakeLock' in navigator;
     setIsSupported(supported);
     if (!supported) {
-      console.log('Screen Wake Lock API not supported.');
+      logger.log('Screen Wake Lock API not supported.');
     }
   }, []);
 
@@ -22,14 +23,14 @@ export const useWakeLock = () => {
         try {
           const lock = await navigator.wakeLock.request('screen');
           lock.addEventListener('release', () => {
-            console.log('Screen Wake Lock was released by the system.');
+            logger.log('Screen Wake Lock was released by the system.');
             setWakeLock(null);
           });
-          console.log('Screen Wake Lock is active.');
+          logger.log('Screen Wake Lock is active.');
           setWakeLock(lock);
         } catch (err: unknown) {
           if (err instanceof Error) {
-            console.error(`Wake Lock request failed: ${err.name}, ${err.message}`);
+            logger.error(`Wake Lock request failed: ${err.name}, ${err.message}`);
           }
         }
       }
@@ -38,7 +39,7 @@ export const useWakeLock = () => {
       if (wakeLock) {
         await wakeLock.release();
         setWakeLock(null);
-        console.log('Screen Wake Lock released programmatically.');
+        logger.log('Screen Wake Lock released programmatically.');
       }
     }
   }, [isSupported, wakeLock]);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,8 +6,8 @@ import enTranslationsFile from './locales/en.json';
 
 // ADD DEBUG LOG HERE
 // Log the entire object now, without truncation
-//console.log('[i18n.ts] Imported fiTranslations:', JSON.stringify(fiTranslationsFile));
-//console.log('[i18n.ts] Imported enTranslations:', JSON.stringify(enTranslationsFile));
+//logger.log('[i18n.ts] Imported fiTranslations:', JSON.stringify(fiTranslationsFile));
+//logger.log('[i18n.ts] Imported enTranslations:', JSON.stringify(enTranslationsFile));
 
 // Create a complete translation object by merging imported and hardcoded values
 const fiTranslations = JSON.parse(JSON.stringify(fiTranslationsFile));

--- a/src/utils/appSettings.ts
+++ b/src/utils/appSettings.ts
@@ -11,6 +11,7 @@ import {
   setLocalStorageItem,
   removeLocalStorageItem,
 } from './localStorage';
+import logger from '@/utils/logger';
 /**
  * Interface for application settings
  */
@@ -44,7 +45,7 @@ export const getAppSettings = async (): Promise<AppSettings> => {
     const settings = JSON.parse(settingsJson);
     return { ...DEFAULT_APP_SETTINGS, ...settings };
   } catch (error) {
-    console.error('Error getting app settings from localStorage:', error);
+    logger.error('Error getting app settings from localStorage:', error);
     return DEFAULT_APP_SETTINGS; // Fallback to default on error
   }
 };
@@ -59,7 +60,7 @@ export const saveAppSettings = async (settings: AppSettings): Promise<boolean> =
     setLocalStorageItem(APP_SETTINGS_KEY, JSON.stringify(settings));
     return true;
   } catch (error) {
-    console.error('Error saving app settings to localStorage:', error);
+    logger.error('Error saving app settings to localStorage:', error);
     return false;
   }
 };
@@ -130,7 +131,7 @@ export const getLastHomeTeamName = async (): Promise<string> => {
     const legacyValue = getLocalStorageItem(LAST_HOME_TEAM_NAME_KEY);
     return legacyValue || '';
   } catch (error) {
-    console.error('Error getting last home team name:', error);
+    logger.error('Error getting last home team name:', error);
     return '';
   }
 };
@@ -148,7 +149,7 @@ export const saveLastHomeTeamName = async (teamName: string): Promise<boolean> =
     setLocalStorageItem(LAST_HOME_TEAM_NAME_KEY, teamName); // Legacy sync save
     return true;
   } catch (error) {
-    console.error('Error saving last home team name:', error);
+    logger.error('Error saving last home team name:', error);
     return false;
   }
 };
@@ -172,7 +173,7 @@ export const resetAppSettings = async (): Promise<boolean> => {
     const success = await saveAppSettings(DEFAULT_APP_SETTINGS);
     return success;
   } catch (error) {
-    console.error('Error resetting app settings:', error);
+    logger.error('Error resetting app settings:', error);
     return false;
   }
 };

--- a/src/utils/game.test.ts
+++ b/src/utils/game.test.ts
@@ -1,4 +1,5 @@
 import { AppState } from '@/types';
+import logger from '@/utils/logger';
 
 // Define placeholder functions for the logic being tested.
 // Use unknown for state parameter and perform type checking inside if needed
@@ -38,7 +39,7 @@ const migrateGameState = (state: unknown): GameState => {
   if (typeof state !== 'object' || state === null) {
       // Handle invalid input, maybe return a default state or throw error
       // For placeholder, let's return a default-like structure
-      console.error("Invalid state passed to migrateGameState");
+      logger.error("Invalid state passed to migrateGameState");
       state = {}; // Reset to empty object to allow defaults below
   }
 

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,9 +1,11 @@
+import logger from '@/utils/logger';
+
 export const getStorage = (): Storage | null => {
   if (typeof window === 'undefined') return null;
   try {
     return window.localStorage;
   } catch (error) {
-    console.error('[localStorage] Access error:', error);
+    logger.error('[localStorage] Access error:', error);
     return null;
   }
 };
@@ -14,7 +16,7 @@ export const getLocalStorageItem = (key: string): string | null => {
   try {
     return storage.getItem(key);
   } catch (error) {
-    console.error(`[getLocalStorageItem] Error getting item for key "${key}":`, error);
+    logger.error(`[getLocalStorageItem] Error getting item for key "${key}":`, error);
     throw error;
   }
 };
@@ -25,7 +27,7 @@ export const setLocalStorageItem = (key: string, value: string): void => {
   try {
     storage.setItem(key, value);
   } catch (error) {
-    console.error(`[setLocalStorageItem] Error setting item for key "${key}":`, error);
+    logger.error(`[setLocalStorageItem] Error setting item for key "${key}":`, error);
     throw error;
   }
 };
@@ -36,7 +38,7 @@ export const removeLocalStorageItem = (key: string): void => {
   try {
     storage.removeItem(key);
   } catch (error) {
-    console.error(`[removeLocalStorageItem] Error removing item for key "${key}":`, error);
+    logger.error(`[removeLocalStorageItem] Error removing item for key "${key}":`, error);
     throw error;
   }
 };
@@ -47,7 +49,7 @@ export const clearLocalStorage = (): void => {
   try {
     storage.clear();
   } catch (error) {
-    console.error('[clearLocalStorage] Error clearing localStorage:', error);
+    logger.error('[clearLocalStorage] Error clearing localStorage:', error);
     throw error;
   }
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,15 @@
+const isProd = process.env.NODE_ENV === 'production';
+
+const logger = {
+  log: (...args: unknown[]) => {
+    if (!isProd) console.log(...args);
+  },
+  warn: (...args: unknown[]) => {
+    if (!isProd) console.warn(...args);
+  },
+  error: (...args: unknown[]) => {
+    console.error(...args);
+  },
+};
+
+export default logger;

--- a/src/utils/masterRoster.ts
+++ b/src/utils/masterRoster.ts
@@ -1,5 +1,6 @@
 import { MASTER_ROSTER_KEY } from '@/config/storageKeys';
 import type { Player } from '@/types';
+import logger from '@/utils/logger';
 
 /**
  * Retrieves the master roster of players from localStorage.
@@ -13,7 +14,7 @@ export const getMasterRoster = async (): Promise<Player[]> => {
     }
     return Promise.resolve(JSON.parse(rosterJson) as Player[]);
   } catch (error) {
-    console.error('[getMasterRoster] Error getting master roster from localStorage:', error);
+    logger.error('[getMasterRoster] Error getting master roster from localStorage:', error);
     return Promise.resolve([]); // Return empty array on error
   }
 };
@@ -28,7 +29,7 @@ export const saveMasterRoster = async (players: Player[]): Promise<boolean> => {
     localStorage.setItem(MASTER_ROSTER_KEY, JSON.stringify(players));
     return Promise.resolve(true);
   } catch (error) {
-    console.error('[saveMasterRoster] Error saving master roster to localStorage:', error);
+    logger.error('[saveMasterRoster] Error saving master roster to localStorage:', error);
     // Handle potential errors, e.g., localStorage quota exceeded
     return Promise.resolve(false);
   }
@@ -47,7 +48,7 @@ export const addPlayerToRoster = async (playerData: {
 }): Promise<Player | null> => {
   const trimmedName = playerData.name?.trim();
   if (!trimmedName) {
-    console.error('[addPlayerToRoster] Validation Failed: Player name cannot be empty.');
+    logger.error('[addPlayerToRoster] Validation Failed: Player name cannot be empty.');
     return Promise.resolve(null);
   }
   
@@ -73,7 +74,7 @@ export const addPlayerToRoster = async (playerData: {
     }
     return Promise.resolve(newPlayer);
   } catch (error) {
-    console.error('[addPlayerToRoster] Unexpected error adding player:', error);
+    logger.error('[addPlayerToRoster] Unexpected error adding player:', error);
     return Promise.resolve(null);
   }
 };
@@ -89,7 +90,7 @@ export const updatePlayerInRoster = async (
   updateData: Partial<Omit<Player, 'id'>>
 ): Promise<Player | null> => {
   if (!playerId) {
-    console.error('[updatePlayerInRoster] Validation Failed: Player ID cannot be empty.');
+    logger.error('[updatePlayerInRoster] Validation Failed: Player ID cannot be empty.');
     return Promise.resolve(null);
   }
 
@@ -98,7 +99,7 @@ export const updatePlayerInRoster = async (
     const playerIndex = currentRoster.findIndex(p => p.id === playerId);
     
     if (playerIndex === -1) {
-      console.error(`[updatePlayerInRoster] Player with ID ${playerId} not found.`);
+      logger.error(`[updatePlayerInRoster] Player with ID ${playerId} not found.`);
       return Promise.resolve(null);
     }
     
@@ -110,7 +111,7 @@ export const updatePlayerInRoster = async (
     
     // Ensure name is not empty if it's being updated
     if (updateData.name !== undefined && !updatedPlayer.name?.trim()) {
-      console.error('[updatePlayerInRoster] Validation Failed: Player name cannot be empty.');
+      logger.error('[updatePlayerInRoster] Validation Failed: Player name cannot be empty.');
       return Promise.resolve(null);
     }
     // Ensure name is trimmed if updated
@@ -130,7 +131,7 @@ export const updatePlayerInRoster = async (
 
     return Promise.resolve(updatedPlayer);
   } catch (error) {
-    console.error('[updatePlayerInRoster] Unexpected error updating player:', error);
+    logger.error('[updatePlayerInRoster] Unexpected error updating player:', error);
     return Promise.resolve(null);
   }
 };
@@ -142,7 +143,7 @@ export const updatePlayerInRoster = async (
  */
 export const removePlayerFromRoster = async (playerId: string): Promise<boolean> => {
   if (!playerId) {
-    console.error('[removePlayerFromRoster] Validation Failed: Player ID cannot be empty.');
+    logger.error('[removePlayerFromRoster] Validation Failed: Player ID cannot be empty.');
     return Promise.resolve(false);
   }
 
@@ -151,7 +152,7 @@ export const removePlayerFromRoster = async (playerId: string): Promise<boolean>
     const updatedRoster = currentRoster.filter(p => p.id !== playerId);
     
     if (updatedRoster.length === currentRoster.length) {
-      console.error(`[removePlayerFromRoster] Player with ID ${playerId} not found.`);
+      logger.error(`[removePlayerFromRoster] Player with ID ${playerId} not found.`);
       return Promise.resolve(false);
     }
     
@@ -159,7 +160,7 @@ export const removePlayerFromRoster = async (playerId: string): Promise<boolean>
     return Promise.resolve(success);
 
   } catch (error) {
-    console.error('[removePlayerFromRoster] Unexpected error removing player:', error);
+    logger.error('[removePlayerFromRoster] Unexpected error removing player:', error);
     return Promise.resolve(false);
   }
 };
@@ -175,7 +176,7 @@ export const setPlayerGoalieStatus = async (
   isGoalie: boolean
 ): Promise<Player | null> => {
   if (!playerId) {
-    console.error('[setPlayerGoalieStatus] Validation Failed: Player ID cannot be empty.');
+    logger.error('[setPlayerGoalieStatus] Validation Failed: Player ID cannot be empty.');
     return Promise.resolve(null);
   }
 
@@ -196,7 +197,7 @@ export const setPlayerGoalieStatus = async (
     });
 
     if (!targetPlayer) {
-      console.error(`[setPlayerGoalieStatus] Player with ID ${playerId} not found.`);
+      logger.error(`[setPlayerGoalieStatus] Player with ID ${playerId} not found.`);
       return Promise.resolve(null);
     }
     
@@ -227,7 +228,7 @@ export const setPlayerGoalieStatus = async (
     return Promise.resolve(targetPlayer || null); // Should always be targetPlayer if found earlier
 
   } catch (error) {
-    console.error('[setPlayerGoalieStatus] Unexpected error:', error);
+    logger.error('[setPlayerGoalieStatus] Unexpected error:', error);
     return Promise.resolve(null);
   }
 };

--- a/src/utils/masterRosterManager.ts
+++ b/src/utils/masterRosterManager.ts
@@ -7,6 +7,7 @@ import {
     setPlayerGoalieStatus as utilSetPlayerGoalieStatus,
     setPlayerFairPlayCardStatus as utilSetPlayerFairPlayCardStatus
 } from '@/utils/masterRoster';
+import logger from '@/utils/logger';
 
 /**
  * Retrieves the master roster of players.
@@ -14,13 +15,13 @@ import {
  * @returns {Promise<Player[]>} The current roster.
  */
 export const getMasterRoster = async (): Promise<Player[]> => {
-    // console.log('[masterRosterManager] getMasterRoster called');
+    // logger.log('[masterRosterManager] getMasterRoster called');
     try {
         const roster = await utilGetMasterRoster();
-        // console.log('[masterRosterManager] Roster fetched by util:', roster);
+        // logger.log('[masterRosterManager] Roster fetched by util:', roster);
         return roster;
     } catch (error) {
-        console.error("[masterRosterManager] Error in getMasterRoster:", error);
+        logger.error("[masterRosterManager] Error in getMasterRoster:", error);
         return []; // Return empty array on error to maintain type consistency
     }
 };
@@ -34,13 +35,13 @@ export const getMasterRoster = async (): Promise<Player[]> => {
 export const addPlayer = async (
     playerData: Omit<Player, 'id' | 'isGoalie' | 'receivedFairPlayCard'>
 ): Promise<Player | null> => {
-    // console.log('[masterRosterManager] addPlayer called with:', playerData);
+    // logger.log('[masterRosterManager] addPlayer called with:', playerData);
     try {
         const newPlayer = await utilAddPlayerToRoster(playerData);
-        // console.log('[masterRosterManager] Player added by util:', newPlayer);
+        // logger.log('[masterRosterManager] Player added by util:', newPlayer);
         return newPlayer;
     } catch (error) {
-        console.error("[masterRosterManager] Error in addPlayer:", error);
+        logger.error("[masterRosterManager] Error in addPlayer:", error);
         return null;
     }
 };
@@ -56,13 +57,13 @@ export const updatePlayer = async (
     playerId: string,
     updates: Partial<Omit<Player, 'id'>>
 ): Promise<Player | null> => {
-    // console.log('[masterRosterManager] updatePlayer called for ID:', playerId, 'with updates:', updates);
+    // logger.log('[masterRosterManager] updatePlayer called for ID:', playerId, 'with updates:', updates);
     try {
         const updatedPlayer = await utilUpdatePlayerInRoster(playerId, updates);
-        // console.log('[masterRosterManager] Player updated by util:', updatedPlayer);
+        // logger.log('[masterRosterManager] Player updated by util:', updatedPlayer);
         return updatedPlayer;
     } catch (error) {
-        console.error(`[masterRosterManager] Error in updatePlayer for ID ${playerId}:`, error);
+        logger.error(`[masterRosterManager] Error in updatePlayer for ID ${playerId}:`, error);
         return null;
     }
 };
@@ -74,13 +75,13 @@ export const updatePlayer = async (
  * @returns {Promise<boolean>} True if the player was successfully removed, false otherwise.
  */
 export const removePlayer = async (playerId: string): Promise<boolean> => {
-    // console.log('[masterRosterManager] removePlayer called for ID:', playerId);
+    // logger.log('[masterRosterManager] removePlayer called for ID:', playerId);
     try {
         const success = await utilRemovePlayerFromRoster(playerId);
-        // console.log('[masterRosterManager] Player removal by util status:', success);
+        // logger.log('[masterRosterManager] Player removal by util status:', success);
         return success;
     } catch (error) {
-        console.error(`[masterRosterManager] Error in removePlayer for ID ${playerId}:`, error);
+        logger.error(`[masterRosterManager] Error in removePlayer for ID ${playerId}:`, error);
         return false;
     }
 };
@@ -96,13 +97,13 @@ export const setGoalieStatus = async (
     playerId: string,
     isGoalie: boolean
 ): Promise<Player | null> => {
-    // console.log('[masterRosterManager] setGoalieStatus called for ID:', playerId, 'to:', isGoalie);
+    // logger.log('[masterRosterManager] setGoalieStatus called for ID:', playerId, 'to:', isGoalie);
     try {
         const updatedPlayer = await utilSetPlayerGoalieStatus(playerId, isGoalie);
-        // console.log('[masterRosterManager] Goalie status updated by util:', updatedPlayer);
+        // logger.log('[masterRosterManager] Goalie status updated by util:', updatedPlayer);
         return updatedPlayer;
     } catch (error) {
-        console.error(`[masterRosterManager] Error in setGoalieStatus for ID ${playerId}:`, error);
+        logger.error(`[masterRosterManager] Error in setGoalieStatus for ID ${playerId}:`, error);
         return null;
     }
 };
@@ -118,13 +119,13 @@ export const setFairPlayCardStatus = async (
     playerId: string,
     receivedFairPlayCard: boolean
 ): Promise<Player | null> => {
-    // console.log('[masterRosterManager] setFairPlayCardStatus called for ID:', playerId, 'to:', receivedFairPlayCard);
+    // logger.log('[masterRosterManager] setFairPlayCardStatus called for ID:', playerId, 'to:', receivedFairPlayCard);
     try {
         const updatedPlayer = await utilSetPlayerFairPlayCardStatus(playerId, receivedFairPlayCard);
-        // console.log('[masterRosterManager] Fair play status updated by util:', updatedPlayer);
+        // logger.log('[masterRosterManager] Fair play status updated by util:', updatedPlayer);
         return updatedPlayer;
     } catch (error) {
-        console.error(`[masterRosterManager] Error in setFairPlayCardStatus for ID ${playerId}:`, error);
+        logger.error(`[masterRosterManager] Error in setFairPlayCardStatus for ID ${playerId}:`, error);
         return null;
     }
 }; 

--- a/src/utils/roster.test.ts
+++ b/src/utils/roster.test.ts
@@ -1,4 +1,5 @@
 import { Player } from '@/types';
+import logger from '@/utils/logger';
 
 // Constants used in the app
 const MASTER_ROSTER_KEY = 'soccerMasterRoster';
@@ -36,7 +37,7 @@ function getRoster(): Player[] {
   try {
     return JSON.parse(roster);
   } catch (error) {
-    console.error("Error parsing roster:", error);
+    logger.error("Error parsing roster:", error);
     return [];
   }
 }

--- a/src/utils/savedGames.ts
+++ b/src/utils/savedGames.ts
@@ -6,6 +6,7 @@ import {
 } from './localStorage';
 import type { SavedGamesCollection, AppState, GameEvent as PageGameEvent, Point, Opponent, IntervalLog } from '@/types';
 import type { Player } from '@/types';
+import logger from '@/utils/logger';
 
 // Note: AppState (imported from @/types) is the primary type used for live game state
 // and for storing games in localStorage via SavedGamesCollection.
@@ -53,7 +54,7 @@ export const getSavedGames = async (): Promise<SavedGamesCollection> => {
     }
     return JSON.parse(gamesJson) as SavedGamesCollection;
   } catch (error) {
-    console.error('Error getting saved games from localStorage:', error);
+    logger.error('Error getting saved games from localStorage:', error);
     throw error;
   }
 };
@@ -68,7 +69,7 @@ export const saveGames = async (games: SavedGamesCollection): Promise<void> => {
     setLocalStorageItem(SAVED_GAMES_KEY, JSON.stringify(games));
     return;
   } catch (error) {
-    console.error('Error saving games to localStorage:', error);
+    logger.error('Error saving games to localStorage:', error);
     throw error;
   }
 };
@@ -90,7 +91,7 @@ export const saveGame = async (gameId: string, gameData: unknown): Promise<AppSt
     await saveGames(allGames);
     return gameData as AppState;
   } catch (error) {
-    console.error('Error saving game:', error);
+    logger.error('Error saving game:', error);
     throw error;
   }
 };
@@ -110,7 +111,7 @@ export const getGame = async (gameId: string): Promise<AppState | null> => {
     const game = allGames[gameId] ? (allGames[gameId] as AppState) : null;
     return game;
   } catch (error) {
-    console.error('Error getting game:', error);
+    logger.error('Error getting game:', error);
     throw error;
   }
 };
@@ -123,22 +124,22 @@ export const getGame = async (gameId: string): Promise<AppState | null> => {
 export const deleteGame = async (gameId: string): Promise<string | null> => {
   try {
     if (!gameId) {
-      console.warn('deleteGame: gameId is null or empty.');
+      logger.warn('deleteGame: gameId is null or empty.');
       return null;
     }
     
     const allGames = await getSavedGames();
     if (!allGames[gameId]) {
-      console.warn(`deleteGame: Game with ID ${gameId} not found.`);
+      logger.warn(`deleteGame: Game with ID ${gameId} not found.`);
       return null; // Game not found
     }
     
     delete allGames[gameId];
     await saveGames(allGames);
-    console.log(`deleteGame: Game with ID ${gameId} successfully deleted.`);
+    logger.log(`deleteGame: Game with ID ${gameId} successfully deleted.`);
     return gameId; // Successfully deleted, return the gameId
   } catch (error) {
-    console.error('Error deleting game:', error);
+    logger.error('Error deleting game:', error);
     throw error; // Re-throw other errors
   }
 };
@@ -186,7 +187,7 @@ export const createGame = async (gameData: Partial<AppState>): Promise<{ gameId:
     const result = await saveGame(gameId, newGameAppState);
     return { gameId, gameData: result };
   } catch (error) {
-    console.error('Error creating new game:', error);
+    logger.error('Error creating new game:', error);
     throw error; // Rethrow to indicate failure
   }
 };
@@ -200,7 +201,7 @@ export const getAllGameIds = async (): Promise<string[]> => {
     const allGames = await getSavedGames();
     return Object.keys(allGames);
   } catch (error) {
-    console.error('Error getting all game IDs:', error);
+    logger.error('Error getting all game IDs:', error);
     throw error;
   }
 };
@@ -230,7 +231,7 @@ export const getFilteredGames = async (filters: {
     }).map(([id, game]) => [id, game as AppState] as [string, AppState]); // Ensure correct tuple type
     return filtered;
   } catch (error) {
-    console.error('Error filtering games:', error);
+    logger.error('Error filtering games:', error);
     throw error;
   }
 };
@@ -280,7 +281,7 @@ export const updateGameDetails = async (
   try {
     const game = await getGame(gameId);
     if (!game) {
-      console.warn(`Game with ID ${gameId} not found for update.`);
+      logger.warn(`Game with ID ${gameId} not found for update.`);
       return null;
     }
     
@@ -292,7 +293,7 @@ export const updateGameDetails = async (
     // saveGame now returns a Promise<AppState>
     return saveGame(gameId, updatedGame);
   } catch (error) {
-    console.error('Error updating game details:', error);
+    logger.error('Error updating game details:', error);
     throw error; // Propagate error
   }
 };
@@ -307,7 +308,7 @@ export const addGameEvent = async (gameId: string, event: PageGameEvent): Promis
   try {
     const game = await getGame(gameId);
     if (!game) {
-      console.warn(`Game with ID ${gameId} not found for adding event.`);
+      logger.warn(`Game with ID ${gameId} not found for adding event.`);
       return null;
     }
     
@@ -318,7 +319,7 @@ export const addGameEvent = async (gameId: string, event: PageGameEvent): Promis
     
     return saveGame(gameId, updatedGame);
   } catch (error) {
-    console.error('Error adding game event:', error);
+    logger.error('Error adding game event:', error);
     throw error;
   }
 };
@@ -334,13 +335,13 @@ export const updateGameEvent = async (gameId: string, eventIndex: number, eventD
   try {
     const game = await getGame(gameId);
     if (!game) {
-      console.warn(`Game with ID ${gameId} not found for updating event.`);
+      logger.warn(`Game with ID ${gameId} not found for updating event.`);
       return null;
     }
     
     const events = [...(game.gameEvents || [])];
     if (eventIndex < 0 || eventIndex >= events.length) {
-      console.warn(`Event index ${eventIndex} out of bounds for game ${gameId}.`);
+      logger.warn(`Event index ${eventIndex} out of bounds for game ${gameId}.`);
       return null;
     }
     
@@ -353,7 +354,7 @@ export const updateGameEvent = async (gameId: string, eventIndex: number, eventD
     
     return saveGame(gameId, updatedGame);
   } catch (error) {
-    console.error('Error updating game event:', error);
+    logger.error('Error updating game event:', error);
     throw error;
   }
 };
@@ -368,13 +369,13 @@ export const removeGameEvent = async (gameId: string, eventIndex: number): Promi
   try {
     const game = await getGame(gameId);
     if (!game) {
-      console.warn(`Game with ID ${gameId} not found for removing event.`);
+      logger.warn(`Game with ID ${gameId} not found for removing event.`);
       return null;
     }
     
     const events = [...(game.gameEvents || [])];
     if (eventIndex < 0 || eventIndex >= events.length) {
-      console.warn(`Event index ${eventIndex} out of bounds for game ${gameId}.`);
+      logger.warn(`Event index ${eventIndex} out of bounds for game ${gameId}.`);
       return null;
     }
     
@@ -387,7 +388,7 @@ export const removeGameEvent = async (gameId: string, eventIndex: number): Promi
     
     return saveGame(gameId, updatedGame);
   } catch (error) {
-    console.error('Error removing game event:', error);
+    logger.error('Error removing game event:', error);
     throw error;
   }
 };
@@ -400,12 +401,12 @@ export const exportGamesAsJson = async (): Promise<string | null> => {
   try {
     const allGames = await getSavedGames();
     if (Object.keys(allGames).length === 0) {
-      console.log('No games to export.');
+      logger.log('No games to export.');
       return null; // Or an empty JSON object string like '{}'
     }
     return JSON.stringify(allGames, null, 2);
   } catch (error) {
-    console.error('Error exporting games as JSON:', error);
+    logger.error('Error exporting games as JSON:', error);
     throw error; // Propagate error
   }
 };
@@ -435,7 +436,7 @@ export const importGamesFromJson = async (
     for (const gameId in gamesToImport) {
       if (Object.prototype.hasOwnProperty.call(gamesToImport, gameId)) {
         if (existingGames[gameId] && !overwrite) {
-          console.log(`Skipping import for existing game ID: ${gameId} (overwrite is false).`);
+          logger.log(`Skipping import for existing game ID: ${gameId} (overwrite is false).`);
           continue;
         }
         const validation = appStateSchema.safeParse(gamesToImport[gameId]);
@@ -453,7 +454,7 @@ export const importGamesFromJson = async (
 
     return importedCount;
   } catch (error) {
-    console.error('Error importing games from JSON:', error);
+    logger.error('Error importing games from JSON:', error);
     throw error; // Propagate error
   }
 };

--- a/src/utils/seasons.ts
+++ b/src/utils/seasons.ts
@@ -1,5 +1,6 @@
 import { SEASONS_LIST_KEY } from '@/config/storageKeys';
 import type { Season } from '@/types'; // Import Season type from shared types
+import logger from '@/utils/logger';
 
 // Define the Season type (consider moving to a shared types file if not already there)
 // export interface Season { // Remove local definition
@@ -20,7 +21,7 @@ export const getSeasons = async (): Promise<Season[]> => {
     }
     return Promise.resolve(JSON.parse(seasonsJson) as Season[]);
   } catch (error) {
-    console.error('[getSeasons] Error reading seasons from localStorage:', error);
+    logger.error('[getSeasons] Error reading seasons from localStorage:', error);
     return Promise.resolve([]); // Resolve with empty array on error
   }
 };
@@ -35,7 +36,7 @@ export const saveSeasons = async (seasons: Season[]): Promise<boolean> => {
     localStorage.setItem(SEASONS_LIST_KEY, JSON.stringify(seasons));
     return Promise.resolve(true);
   } catch (error) {
-    console.error('[saveSeasons] Error saving seasons to localStorage:', error);
+    logger.error('[saveSeasons] Error saving seasons to localStorage:', error);
     return Promise.resolve(false);
   }
 };
@@ -48,14 +49,14 @@ export const saveSeasons = async (seasons: Season[]): Promise<boolean> => {
 export const addSeason = async (newSeasonName: string): Promise<Season | null> => {
   const trimmedName = newSeasonName.trim();
   if (!trimmedName) {
-    console.error('[addSeason] Validation failed: Season name cannot be empty.');
+    logger.error('[addSeason] Validation failed: Season name cannot be empty.');
     return Promise.resolve(null);
   }
 
   try {
     const currentSeasons = await getSeasons();
     if (currentSeasons.some(s => s.name.toLowerCase() === trimmedName.toLowerCase())) {
-      console.error(`[addSeason] Validation failed: A season with name "${trimmedName}" already exists.`);
+      logger.error(`[addSeason] Validation failed: A season with name "${trimmedName}" already exists.`);
       return Promise.resolve(null);
     }
     const newSeason: Season = {
@@ -70,7 +71,7 @@ export const addSeason = async (newSeasonName: string): Promise<Season | null> =
     }
     return Promise.resolve(newSeason);
   } catch (error) {
-    console.error('[addSeason] Unexpected error adding season:', error);
+    logger.error('[addSeason] Unexpected error adding season:', error);
     return Promise.resolve(null);
   }
 };
@@ -82,7 +83,7 @@ export const addSeason = async (newSeasonName: string): Promise<Season | null> =
  */
 export const updateSeason = async (updatedSeasonData: Season): Promise<Season | null> => {
   if (!updatedSeasonData || !updatedSeasonData.id || !updatedSeasonData.name?.trim()) {
-    console.error('[updateSeason] Invalid season data provided for update.');
+    logger.error('[updateSeason] Invalid season data provided for update.');
     return Promise.resolve(null);
   }
   const trimmedName = updatedSeasonData.name.trim();
@@ -92,12 +93,12 @@ export const updateSeason = async (updatedSeasonData: Season): Promise<Season | 
     const seasonIndex = currentSeasons.findIndex(s => s.id === updatedSeasonData.id);
 
     if (seasonIndex === -1) {
-      console.error(`[updateSeason] Season with ID ${updatedSeasonData.id} not found.`);
+      logger.error(`[updateSeason] Season with ID ${updatedSeasonData.id} not found.`);
       return Promise.resolve(null);
     }
 
     if (currentSeasons.some(s => s.id !== updatedSeasonData.id && s.name.toLowerCase() === trimmedName.toLowerCase())) {
-      console.error(`[updateSeason] Validation failed: Another season with name "${trimmedName}" already exists.`);
+      logger.error(`[updateSeason] Validation failed: Another season with name "${trimmedName}" already exists.`);
       return Promise.resolve(null);
     }
 
@@ -111,7 +112,7 @@ export const updateSeason = async (updatedSeasonData: Season): Promise<Season | 
     }
     return Promise.resolve(seasonsToUpdate[seasonIndex]);
   } catch (error) {
-    console.error('[updateSeason] Unexpected error updating season:', error);
+    logger.error('[updateSeason] Unexpected error updating season:', error);
     return Promise.resolve(null);
   }
 };
@@ -123,7 +124,7 @@ export const updateSeason = async (updatedSeasonData: Season): Promise<Season | 
  */
 export const deleteSeason = async (seasonId: string): Promise<boolean> => {
   if (!seasonId) {
-     console.error('[deleteSeason] Invalid season ID provided.');
+     logger.error('[deleteSeason] Invalid season ID provided.');
      return Promise.resolve(false);
   }
   try {
@@ -131,14 +132,14 @@ export const deleteSeason = async (seasonId: string): Promise<boolean> => {
     const updatedSeasons = currentSeasons.filter(s => s.id !== seasonId);
 
     if (updatedSeasons.length === currentSeasons.length) {
-      console.error(`[deleteSeason] Season with id ${seasonId} not found.`);
+      logger.error(`[deleteSeason] Season with id ${seasonId} not found.`);
       return Promise.resolve(false);
     }
 
     const success = await saveSeasons(updatedSeasons);
     return Promise.resolve(success);
   } catch (error) {
-    console.error('[deleteSeason] Unexpected error deleting season:', error);
+    logger.error('[deleteSeason] Unexpected error deleting season:', error);
     return Promise.resolve(false);
   }
 }; 

--- a/src/utils/tournaments.ts
+++ b/src/utils/tournaments.ts
@@ -1,5 +1,6 @@
 import { TOURNAMENTS_LIST_KEY } from '@/config/storageKeys';
 import type { Tournament } from '@/types'; // Import Tournament type from shared types
+import logger from '@/utils/logger';
 
 // Define the Tournament type (consider moving to a shared types file)
 // export interface Tournament { // Remove local definition
@@ -20,7 +21,7 @@ export const getTournaments = async (): Promise<Tournament[]> => {
     }
     return Promise.resolve(JSON.parse(tournamentsJson) as Tournament[]);
   } catch (error) {
-    console.error('[getTournaments] Error getting tournaments from localStorage:', error);
+    logger.error('[getTournaments] Error getting tournaments from localStorage:', error);
     return Promise.resolve([]);
   }
 };
@@ -35,7 +36,7 @@ export const saveTournaments = async (tournaments: Tournament[]): Promise<boolea
     localStorage.setItem(TOURNAMENTS_LIST_KEY, JSON.stringify(tournaments));
     return Promise.resolve(true);
   } catch (error) {
-    console.error('[saveTournaments] Error saving tournaments to localStorage:', error);
+    logger.error('[saveTournaments] Error saving tournaments to localStorage:', error);
     return Promise.resolve(false);
   }
 };
@@ -48,14 +49,14 @@ export const saveTournaments = async (tournaments: Tournament[]): Promise<boolea
 export const addTournament = async (newTournamentName: string): Promise<Tournament | null> => {
   const trimmedName = newTournamentName.trim();
   if (!trimmedName) {
-    console.error('[addTournament] Validation failed: Tournament name cannot be empty.');
+    logger.error('[addTournament] Validation failed: Tournament name cannot be empty.');
     return Promise.resolve(null);
   }
 
   try {
     const currentTournaments = await getTournaments();
     if (currentTournaments.some(t => t.name.toLowerCase() === trimmedName.toLowerCase())) {
-      console.error(`[addTournament] Validation failed: A tournament with name "${trimmedName}" already exists.`);
+      logger.error(`[addTournament] Validation failed: A tournament with name "${trimmedName}" already exists.`);
       return Promise.resolve(null);
     }
     const newTournament: Tournament = {
@@ -70,7 +71,7 @@ export const addTournament = async (newTournamentName: string): Promise<Tourname
     }
     return Promise.resolve(newTournament);
   } catch (error) {
-    console.error('[addTournament] Unexpected error adding tournament:', error);
+    logger.error('[addTournament] Unexpected error adding tournament:', error);
     return Promise.resolve(null);
   }
 };
@@ -82,7 +83,7 @@ export const addTournament = async (newTournamentName: string): Promise<Tourname
  */
 export const updateTournament = async (updatedTournamentData: Tournament): Promise<Tournament | null> => {
   if (!updatedTournamentData || !updatedTournamentData.id || !updatedTournamentData.name?.trim()) {
-    console.error('[updateTournament] Invalid tournament data provided for update.');
+    logger.error('[updateTournament] Invalid tournament data provided for update.');
     return Promise.resolve(null);
   }
   const trimmedName = updatedTournamentData.name.trim();
@@ -92,12 +93,12 @@ export const updateTournament = async (updatedTournamentData: Tournament): Promi
     const tournamentIndex = currentTournaments.findIndex(t => t.id === updatedTournamentData.id);
 
     if (tournamentIndex === -1) {
-      console.error(`[updateTournament] Tournament with ID ${updatedTournamentData.id} not found.`);
+      logger.error(`[updateTournament] Tournament with ID ${updatedTournamentData.id} not found.`);
       return Promise.resolve(null);
     }
 
     if (currentTournaments.some(t => t.id !== updatedTournamentData.id && t.name.toLowerCase() === trimmedName.toLowerCase())) {
-      console.error(`[updateTournament] Validation failed: Another tournament with name "${trimmedName}" already exists.`);
+      logger.error(`[updateTournament] Validation failed: Another tournament with name "${trimmedName}" already exists.`);
       return Promise.resolve(null);
     }
 
@@ -111,7 +112,7 @@ export const updateTournament = async (updatedTournamentData: Tournament): Promi
     }
     return Promise.resolve(tournamentsToUpdate[tournamentIndex]);
   } catch (error) {
-    console.error('[updateTournament] Unexpected error updating tournament:', error);
+    logger.error('[updateTournament] Unexpected error updating tournament:', error);
     return Promise.resolve(null);
   }
 };
@@ -123,7 +124,7 @@ export const updateTournament = async (updatedTournamentData: Tournament): Promi
  */
 export const deleteTournament = async (tournamentId: string): Promise<boolean> => {
   if (!tournamentId) {
-    console.error('[deleteTournament] Invalid tournament ID provided.');
+    logger.error('[deleteTournament] Invalid tournament ID provided.');
     return Promise.resolve(false);
   }
   try {
@@ -131,14 +132,14 @@ export const deleteTournament = async (tournamentId: string): Promise<boolean> =
     const updatedTournaments = currentTournaments.filter(t => t.id !== tournamentId);
 
     if (updatedTournaments.length === currentTournaments.length) {
-      console.error(`[deleteTournament] Tournament with id ${tournamentId} not found.`);
+      logger.error(`[deleteTournament] Tournament with id ${tournamentId} not found.`);
       return Promise.resolve(false);
     }
 
     const success = await saveTournaments(updatedTournaments);
     return Promise.resolve(success);
   } catch (error) {
-    console.error('[deleteTournament] Unexpected error deleting tournament:', error);
+    logger.error('[deleteTournament] Unexpected error deleting tournament:', error);
     return Promise.resolve(false);
   }
 }; 


### PR DESCRIPTION
## Summary
- verify timer improvements done
- add toast provider with tests
- use toast for quick save feedback
- introduce logger utility and replace verbose `console` calls
- update docs and README manual testing instructions
- add manual verification steps to deep code review tasks

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d12c79590832ca3ea2bb233acdd8c