### PR TITLE
Set Finnish as default language

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,7 +40,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="fi">
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
@@ -57,5 +57,4 @@ export default function RootLayout({
         <Analytics />
       </body>
     </html>
-  );
-}
+  );}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,8 +1,9 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 // Use the comprehensive translation files
-import fi from './locales/fi/translation.json';
-import en from './locales/en/translation.json';
+// Load translations from the public folder so all keys are available
+import fi from '../public/locales/fi/common.json';
+import en from '../public/locales/en/common.json';
 
 export const resources = {
   fi: { translation: fi },


### PR DESCRIPTION
## Summary
- load translations from `public/locales` so all keys are available
- set default HTML lang to Finnish

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d61c24c14832ca68d8f5f7c26a0a2