### PR TITLE
Fix missing i18n keys

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -50,6 +50,7 @@
   "controlBar.exportData": "Export Data",
   "controlBar.toggleLanguage": "Change Language",
   "controlBar.backButton": "Back",
+  "common.notSet": "Not Set",
   "timerOverlay.intervalLabel": "Interval (min):",
   "timerOverlay.confirmSubButton": "Substitution Made",
   "timerOverlay.historyTitle": "Play Time History",
@@ -173,7 +174,9 @@
     "noAssisterPlaceholder": "-- No Assist --",
     "cancelButton": "Cancel",
     "logButton": "Log Goal",
-    "logOpponentButton": "Log Opponent Goal"
+    "logOpponentButton": "Log Opponent Goal",
+    "logOpponentGoalButtonShort": "Opponent +1",
+    "logOpponentGoalTooltip": "Record a goal for the opponent at the current time"
   },
   "trainingResourcesModal": {
     "title": "Training Resources",
@@ -228,7 +231,31 @@
     "draw": "Draw",
     "tasoLink": "Log data to Taso",
     "exportJsonButton": "Export JSON",
-    "exportExcelButton": "Export Excel"
+    "exportExcelButton": "Export Excel",
+    "tabs": {
+      "currentGame": "Current",
+      "season": "Season",
+      "tournament": "Tournament",
+      "overall": "Overall",
+      "player": "Player"
+    },
+    "filterAllSeasons": "All Seasons",
+    "filterAllTournaments": "All Tournaments",
+    "titleSeason": "Season Stats",
+    "titleTournament": "Tournament Stats",
+    "titleOverall": "Overall Stats",
+    "titleCurrentGame": "Current Game Stats",
+    "invalidTimeFormat": "Invalid time format. MM:SS",
+    "scorerRequired": "Scorer must be selected.",
+    "confirmDeleteEvent": "Are you sure you want to delete this event? This cannot be undone.",
+    "overallSummary": "Overall Summary",
+    "allSeasonsStats": "All Seasons Stats",
+    "allTournamentsStats": "All Tournaments Stats",
+    "seasonStats": "Season Statistics",
+    "tournamentStats": "Tournament Statistics",
+    "noStatsAvailable": "No statistics available.",
+    "notesPlaceholder": "Add notes here...",
+    "noNotes": "No notes added"
   },
   "controlBar": {
     "hardReset": "Hard Reset App",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -49,6 +49,7 @@
   "controlBar.exportData": "Vie tiedot",
   "controlBar.toggleLanguage": "Vaihda kieli",
   "controlBar.backButton": "Takaisin",
+  "common.notSet": "Ei asetettu",
   "timerOverlay.intervalLabel": "Vaihtoväli (min):",
   "timerOverlay.confirmSubButton": "Vaihto tehty",
   "timerOverlay.historyTitle": "Peliaikahistoria",
@@ -172,7 +173,9 @@
     "noAssisterPlaceholder": "-- Ei Syöttäjää --",
     "cancelButton": "Peruuta",
     "logButton": "Kirjaa maali",
-    "logOpponentButton": "Kirjaa Vastustajan Maali"
+    "logOpponentButton": "Kirjaa Vastustajan Maali",
+    "logOpponentGoalButtonShort": "Vastustaja +1",
+    "logOpponentGoalTooltip": "Kirjaa vastustajalle maali nykyiseen aikaan"
   },
   "trainingResourcesModal": {
     "title": "Harjoitusmateriaalit",
@@ -227,7 +230,31 @@
     "draw": "Tasapeli",
     "tasoLink": "Taso",
     "exportJsonButton": "Lataa JSON",
-    "exportExcelButton": "Lataa EXCEL"
+    "exportExcelButton": "Lataa EXCEL",
+    "tabs": {
+      "currentGame": "Nykyinen",
+      "season": "Kausi",
+      "tournament": "Turnaus",
+      "overall": "Kaikki",
+      "player": "Pelaaja"
+    },
+    "filterAllSeasons": "Kaikki kaudet",
+    "filterAllTournaments": "Kaikki turnaukset",
+    "titleSeason": "Kausitilastot",
+    "titleTournament": "Turnaustilastot",
+    "titleOverall": "Kokonaistilastot",
+    "titleCurrentGame": "Nykyisen pelin tilastot",
+    "invalidTimeFormat": "Virheellinen aikamuoto. MM:SS",
+    "scorerRequired": "Maalintekijä on valittava.",
+    "confirmDeleteEvent": "Haluatko varmasti poistaa tapahtuman? Tätä ei voi perua.",
+    "overallSummary": "Kokonaisyhteenveto",
+    "allSeasonsStats": "Kaikkien kausien tilastot",
+    "allTournamentsStats": "Kaikkien turnausten tilastot",
+    "seasonStats": "Kausitilastot",
+    "tournamentStats": "Turnaustilastot",
+    "noStatsAvailable": "Ei tilastoja saatavilla.",
+    "notesPlaceholder": "Lisää muistiinpanot tähän...",
+    "noNotes": "Ei muistiinpanoja"
   },
   "saveGameModal": {
     "title": "Tallenna Peli Nimellä...",


### PR DESCRIPTION
## Summary
- add missing translations for GameStatsModal and GoalLogModal
- add `common.notSet` key in EN and FI locales

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686d68398a08832cbd8770f6c0cdd83f