### PR TITLE
Implement translation task completion and new unit tests

### DIFF
--- a/.docs/deep-code-review-tasks.md
+++ b/.docs/deep-code-review-tasks.md
@@ -58,13 +58,17 @@ Manual verification after implementing the above:
 ## 6. Translation Maintenance
 - [x] The custom augmentations in `src/i18n.ts` complicate merging JSON locale files. Investigate generating type definitions for translation keys and consolidating all translations in JSON to avoid runtime mutations.
 
+Status: **Done**
+
 Manual verification after implementing the above:
   1. Run `npm run generate:i18n-types` and verify `npx tsc src/i18n-types.ts` completes without errors.
   2. Switch languages in the app and confirm all strings render correctly without runtime warnings.
 
 ## 7. Additional Testing
-- [ ] Extend unit tests for `useGameSessionReducer` to cover score adjustment and timer reset edge cases.
-- [ ] Add smoke tests for the modal context to ensure modals do not interfere with each other when opened sequentially.
+- [x] Extend unit tests for `useGameSessionReducer` to cover score adjustment and timer reset edge cases.
+- [x] Add smoke tests for the modal context to ensure modals do not interfere with each other when opened sequentially.
+
+Status: **Done**
 
 Manual verification after implementing the above:
   1. Run all Jest suites and ensure new reducer tests pass.

--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -1,0 +1,11 @@
+# Manual Testing Guide
+
+Use this short checklist to manually verify key workflows after making changes to the app:
+
+1. **Start a new game and adjust scores** – Add and remove goals for both teams. Ensure the score never goes below zero and updates instantly in the UI.
+2. **Reset the game timer** – Begin a period, let the timer run, then trigger both "Reset Timer" and "Reset Game" actions. Confirm the timer and period values reset as expected.
+3. **Open modals sequentially** – Open Game Settings, Load Game and Roster modals one after another. Each should appear without closing the others unexpectedly and allow closing individually.
+4. **Switch languages** – Toggle between English and Finnish and verify all visible text changes without reloading the page.
+5. **Save and reload a game** – Perform a quick save, refresh the page and load the saved game to confirm state persistence.
+
+Running through these steps after updates helps catch regressions before deploying.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The app is designed to be an all-in-one digital assistant for game day, from pre
 6. Run `npm run generate:i18n-types` and ensure `src/i18n-types.ts` is updated without errors.
 7. Switch the language selector between English and Finnish and confirm all text updates immediately.
 8. Build the project with `npm run build` and open the production build to verify no missing translation warnings appear.
+9. Review the additional [Manual Testing Guide](./MANUAL_TESTING.md) for steps covering score updates, timer resets and modal interactions.
 
 ---
 

--- a/src/contexts/__tests__/ModalProvider.test.tsx
+++ b/src/contexts/__tests__/ModalProvider.test.tsx
@@ -14,3 +14,27 @@ test('modal context toggles state', () => {
 
   expect(result.current.isGameSettingsModalOpen).toBe(true);
 });
+
+test('modals operate independently when opened sequentially', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <ModalProvider>{children}</ModalProvider>
+  );
+  const { result } = renderHook(() => useModalContext(), { wrapper });
+
+  act(() => {
+    result.current.setIsGameSettingsModalOpen(true);
+    result.current.setIsLoadGameModalOpen(true);
+  });
+
+  expect(result.current.isGameSettingsModalOpen).toBe(true);
+  expect(result.current.isLoadGameModalOpen).toBe(true);
+
+  act(() => {
+    result.current.setIsGameSettingsModalOpen(false);
+    result.current.setIsRosterModalOpen(true);
+  });
+
+  expect(result.current.isGameSettingsModalOpen).toBe(false);
+  expect(result.current.isLoadGameModalOpen).toBe(true);
+  expect(result.current.isRosterModalOpen).toBe(true);
+});

--- a/src/hooks/__tests__/useGameSessionReducer.test.ts
+++ b/src/hooks/__tests__/useGameSessionReducer.test.ts
@@ -1,0 +1,66 @@
+import { gameSessionReducer, GameSessionState } from '../useGameSessionReducer';
+
+const baseState: GameSessionState = {
+  teamName: '',
+  opponentName: '',
+  gameDate: '',
+  homeScore: 0,
+  awayScore: 0,
+  gameNotes: '',
+  homeOrAway: 'home',
+  numberOfPeriods: 2,
+  periodDurationMinutes: 10,
+  currentPeriod: 1,
+  gameStatus: 'notStarted',
+  selectedPlayerIds: [],
+  seasonId: '',
+  tournamentId: '',
+  gameLocation: '',
+  gameTime: '',
+  gameEvents: [],
+  timeElapsedInSeconds: 0,
+  startTimestamp: null,
+  isTimerRunning: false,
+  subIntervalMinutes: 5,
+  nextSubDueTimeSeconds: 300,
+  subAlertLevel: 'none',
+  lastSubConfirmationTimeSeconds: 0,
+  completedIntervalDurations: [],
+  showPlayerNames: true,
+};
+
+describe('gameSessionReducer', () => {
+  test('adjust score for goal event does not go negative', () => {
+    let state = { ...baseState, homeScore: 1, awayScore: 0, homeOrAway: 'home' };
+    state = gameSessionReducer(state, { type: 'ADJUST_SCORE_FOR_EVENT', payload: { eventType: 'goal', action: 'delete' } });
+    expect(state.homeScore).toBe(0);
+    state = gameSessionReducer(state, { type: 'ADJUST_SCORE_FOR_EVENT', payload: { eventType: 'goal', action: 'delete' } });
+    expect(state.homeScore).toBe(0);
+  });
+
+  test('reset timer only resets to start of current period', () => {
+    const state = gameSessionReducer(
+      { ...baseState, currentPeriod: 2, timeElapsedInSeconds: 650, subIntervalMinutes: 5 },
+      { type: 'RESET_TIMER_ONLY' }
+    );
+    const periodStart = (2 - 1) * 10 * 60;
+    expect(state.timeElapsedInSeconds).toBe(periodStart);
+    expect(state.isTimerRunning).toBe(false);
+    expect(state.nextSubDueTimeSeconds).toBe(periodStart + 5 * 60);
+    expect(state.lastSubConfirmationTimeSeconds).toBe(periodStart);
+    expect(state.subAlertLevel).toBe('none');
+  });
+
+  test('reset timer and game progress resets scores and period', () => {
+    const state = gameSessionReducer(
+      { ...baseState, homeScore: 2, awayScore: 1, currentPeriod: 2, timeElapsedInSeconds: 500 },
+      { type: 'RESET_TIMER_AND_GAME_PROGRESS', payload: { subIntervalMinutes: 4 } }
+    );
+    expect(state.homeScore).toBe(0);
+    expect(state.awayScore).toBe(0);
+    expect(state.currentPeriod).toBe(1);
+    expect(state.timeElapsedInSeconds).toBe(0);
+    expect(state.subIntervalMinutes).toBe(4);
+    expect(state.nextSubDueTimeSeconds).toBe(4 * 60);
+  });
+});


### PR DESCRIPTION
## Summary
- mark translation maintenance task as complete
- expand manual testing documentation
- add reducer unit tests and modal context smoke test
- document manual testing workflow and reference in README

## Testing
- `npm run generate:i18n-types`
- `npx tsc src/i18n-types.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d77d05338832ca32bc2839d69955f