### PR TITLE
Add bilingual app showcase docs

### DIFF
--- a/.docs/showcase/app-showcase-en.md
+++ b/.docs/showcase/app-showcase-en.md
@@ -1,0 +1,48 @@
+# Soccer Pre-Game & Tactics Board
+
+## Overview
+Modern PWA that turns phones and tablets into a complete coaching assistant for match day.
+
+## The Problem
+Coaches often juggle notebooks, spreadsheets and timer apps, losing valuable insights and wasting precious time on the sideline.
+
+## Our Solution
+The Soccer Pre-Game app merges roster management, live event logging and an interactive tactics board in one streamlined interface. Plan, execute and analyze without leaving the field.
+
+## Key Features
+### Match Preparation
+- **Master roster management** with jersey numbers and goalie status.
+- **Season & tournament organization** to keep games grouped.
+- **Drag-and-drop tactics board** to arrange formations before kickoff.
+
+### Live Game Management
+- **Large overlay game clock** with start, pause and reset.
+- **Automatic substitution reminders** at custom intervals.
+- **Quick event logging** for goals, assists and cards.
+- **Freehand drawing tools** to illustrate adjustments in real time.
+
+### Analytics & Insights
+- **Sortable statistics modal** showing game summaries and player trends.
+- **Aggregated views** for single games or entire competitions.
+- **Export data** as JSON or CSV for further analysis or sharing.
+- **Save multiple game states** and back up or restore all data.
+
+### Technology Highlights
+- **Offline-ready PWA** built with Next.js and React.
+- **Responsive touch-friendly interface** for phones, tablets and laptops.
+- **Automatic update notifications** when new versions launch.
+- **Internationalization** with English and Finnish translations.
+
+## Typical Workflow
+1. Set up your roster and organize matches into seasons or tournaments.
+2. Drag players into formation on the tactics board before kickoff.
+3. Track goals, cards and substitutions while the timer runs.
+4. Adjust tactics with drawing tools and check live statistics.
+5. After the final whistle, review detailed player stats and export data.
+6. Save the game for later review or back up all app data.
+
+## Screenshots
+![TODO: Home screen screenshot](path/to/home-screen.png)
+![TODO: Tactics board screenshot](path/to/tactics-board.png)
+![TODO: Statistics modal screenshot](path/to/stats-modal.png)
+

--- a/.docs/showcase/app-showcase-fi.md
+++ b/.docs/showcase/app-showcase-fi.md
@@ -1,0 +1,48 @@
+# Soccer Pre-Game & Tactics Board
+
+## Yleiskuvaus
+Moderni PWA, joka muuttaa puhelimet ja tabletit täysiverisiksi valmentajan työkaluiksi ottelupäivänä.
+
+## Ratkaistava ongelma
+Valmentajat sähläävät usein muistivihkojen, taulukoiden ja ajastinsovellusten kanssa, jolloin tärkeitä havaintoja katoaa ja aikaa kuluu hukkaan kentän laidalla.
+
+## Ratkaisumme
+Soccer Pre-Game yhdistää pelaajaluettelon hallinnan, reaaliaikaisen tapahtumakirjauksen ja interaktiivisen taktiikkataulun yhteen selkeään käyttöliittymään. Voit suunnitella, toteuttaa ja analysoida peliä poistumatta kentältä.
+
+## Keskeiset ominaisuudet
+### Otteluun valmistautuminen
+- **Päärosterin hallinta**, jossa pelinumerot ja maalivahdin tieto.
+- **Kaudet ja turnaukset** pelien jäsentämiseen.
+- **Raahattava taktiikkataulu** muodostelmien suunnitteluun ennen aloitusta.
+
+### Pelin aikainen ohjaus
+- **Näyttävä ottelukello** käynnistys-, pysäytys- ja nollauspainikkein.
+- **Automaattiset vaihtomuistutukset** valitulla aikavälillä.
+- **Nopea tapahtumakirjaus** maaleille, syötöille ja korteille.
+- **Vapaapiirto** taktiikoiden nopeaan havainnointiin.
+
+### Tilastot ja analytiikka
+- **Lajiteltava tilastonäkymä**, jossa ottelun yhteenveto ja pelaajatrendit.
+- **Koontinäkymät** yksittäisille peleille tai koko kilpailulle.
+- **Datan vienti** JSON- tai CSV-muodossa jatkokäyttöä varten.
+- **Pelitilanteiden tallennus** sekä koko datan varmuuskopiointi ja palautus.
+
+### Teknologia
+- **Offline-valmis PWA** rakennettuna Next.js:llä ja Reactilla.
+- **Kosketusystävällinen käyttöliittymä** toimii puhelimilla, tableteilla ja tietokoneilla.
+- **Automaattiset päivitysilmoitukset** uusista versioista.
+- **Kansainvälistys** suomeksi ja englanniksi.
+
+## Tyypillinen käyttökulku
+1. Määritä rosteri ja järjestä pelit kausiksi tai turnauksiksi.
+2. Asettele pelaajat taktiikkataululle ennen avauspotkua.
+3. Seuraa maaleja, kortteja ja vaihtoja kellon pyöriessä.
+4. Piirrä tarvittavat muutokset ja tarkastele tilastoja kesken pelin.
+5. Vihellyksen jälkeen tutki pelaajatilastoja ja vie data.
+6. Tallenna peli myöhempää tarkastelua varten tai varmuuskopioi kaikki data.
+
+## Kuvakaappaukset
+![TODO: Kotinäkymän kuvakaappaus](path/to/home-screen.png)
+![TODO: Taktiikkataulun kuvakaappaus](path/to/tactics-board.png)
+![TODO: Tilastonäkymän kuvakaappaus](path/to/stats-modal.png)
+


### PR DESCRIPTION
## Summary
- create `.docs/showcase` folder with showcase docs
- document key features and workflow in English and Finnish
- improve marketing language for new users and investors

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e31e455e0832c82cc4125696886d8