### PR TITLE
Add instructions modal with persistent flag

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -70,6 +70,7 @@ interface ControlBarProps {
   onToggleTacticsBoard: () => void;
   onAddHomeDisc: () => void;
   onAddOpponentDisc: () => void;
+  onToggleInstructionsModal: () => void;
 }
 
 const ControlBar: React.FC<ControlBarProps> = ({
@@ -100,6 +101,7 @@ const ControlBar: React.FC<ControlBarProps> = ({
   onToggleTacticsBoard,
   onAddHomeDisc,
   onAddOpponentDisc,
+  onToggleInstructionsModal,
 }) => {
   const { t, i18n } = useTranslation(); // Standard hook
   logger.log('[ControlBar Render] Received highlightRosterButton prop:', highlightRosterButton); // <<< Log prop value
@@ -239,8 +241,8 @@ const ControlBar: React.FC<ControlBarProps> = ({
         </button>
 
         {/* <<< ADD Game Settings Button >>> */}
-        <button 
-            onClick={onOpenGameSettingsModal} 
+        <button
+            onClick={onOpenGameSettingsModal}
             // Disable if no game is loaded? Keep enabled for consistency?
             // Let's keep it enabled, the modal itself might handle the state.
             // disabled={!isGameLoaded} 
@@ -248,6 +250,14 @@ const ControlBar: React.FC<ControlBarProps> = ({
             title={t('controlBar.gameSettings', 'Game Settings') ?? "Game Settings"}
         >
             <HiOutlineAdjustmentsHorizontal className={iconSize} />
+        </button>
+
+        <button
+          onClick={onToggleInstructionsModal}
+          className={`${baseButtonStyle} ${secondaryColor}`}
+          title={t('controlBar.appGuide') ?? 'App Guide'}
+        >
+            <HiOutlineQuestionMarkCircle className={iconSize} />
         </button>
 
         {/* Toggle Overlay Button */}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -14,6 +14,7 @@ import NewGameSetupModal from '@/components/NewGameSetupModal';
 import RosterSettingsModal from '@/components/RosterSettingsModal';
 import GameSettingsModal from '@/components/GameSettingsModal';
 import SeasonTournamentManagementModal from '@/components/SeasonTournamentManagementModal';
+import InstructionsModal from '@/components/InstructionsModal';
 import { useTranslation } from 'react-i18next';
 import { useGameState, UseGameStateReturn } from '@/hooks/useGameState';
 import GameInfoBar from '@/components/GameInfoBar';
@@ -34,6 +35,8 @@ import { saveGame as utilSaveGame, deleteGame as utilDeleteGame, getLatestGameId
 import {
   saveCurrentGameIdSetting as utilSaveCurrentGameIdSetting,
   resetAppSettings as utilResetAppSettings,
+  getHasSeenAppGuide,
+  saveHasSeenAppGuide,
 } from '@/utils/appSettings';
 import { deleteSeason as utilDeleteSeason, updateSeason as utilUpdateSeason, addSeason as utilAddSeason } from '@/utils/seasons';
 import { deleteTournament as utilDeleteTournament, updateTournament as utilUpdateTournament, addTournament as utilAddTournament } from '@/utils/tournaments';
@@ -375,6 +378,7 @@ function HomePage() {
 
   // --- Timer State (Still needed here) ---
   const [showLargeTimerOverlay, setShowLargeTimerOverlay] = useState<boolean>(false); // State for overlay visibility
+  const [isInstructionsModalOpen, setIsInstructionsModalOpen] = useState<boolean>(false);
   
   // --- Modal States handled via context ---
 
@@ -734,6 +738,11 @@ function HomePage() {
           removeLocalStorageItem(TIMER_STATE_KEY);
         }
         // --- END TIMER RESTORATION LOGIC ---
+
+        const seenGuide = await getHasSeenAppGuide();
+        if (!seenGuide) {
+          setIsInstructionsModalOpen(true);
+        }
 
         // This is now the single source of truth for loading completion.
         setInitialLoadComplete(true);
@@ -1293,6 +1302,13 @@ function HomePage() {
   // Training Resources Modal
   const handleToggleTrainingResources = () => {
     setIsTrainingResourcesOpen(!isTrainingResourcesOpen);
+  };
+
+  const handleToggleInstructionsModal = () => {
+    if (isInstructionsModalOpen) {
+      saveHasSeenAppGuide(true);
+    }
+    setIsInstructionsModalOpen(!isInstructionsModalOpen);
   };
 
   // NEW: Handler for Hard Reset
@@ -2426,14 +2442,19 @@ function HomePage() {
           onToggleTacticsBoard={handleToggleTacticsBoard}
           onAddHomeDisc={() => handleAddTacticalDisc('home')}
           onAddOpponentDisc={() => handleAddTacticalDisc('opponent')}
+          onToggleInstructionsModal={handleToggleInstructionsModal}
         />
       </div>
 
       {/* Modals and Overlays */}
       {/* Training Resources Modal */}
-      <TrainingResourcesModal 
-        isOpen={isTrainingResourcesOpen} 
+      <TrainingResourcesModal
+        isOpen={isTrainingResourcesOpen}
         onClose={handleToggleTrainingResources}
+      />
+      <InstructionsModal
+        isOpen={isInstructionsModalOpen}
+        onClose={handleToggleInstructionsModal}
       />
       {/* Goal Log Modal */}
       <GoalLogModal 

--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { HiOutlineXMark } from 'react-icons/hi2';
+
+interface InstructionsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const InstructionsModal: React.FC<InstructionsModalProps> = ({ isOpen, onClose }) => {
+  const { t } = useTranslation();
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-[60] font-display">
+      <div className="bg-slate-800 flex flex-col h-full w-full bg-noise-texture relative overflow-hidden">
+        <div className="absolute inset-0 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent pointer-events-none" />
+        <div className="absolute inset-0 bg-indigo-600/10 mix-blend-soft-light pointer-events-none" />
+        <div className="absolute top-0 -left-1/4 w-1/2 h-1/2 bg-sky-400/10 blur-3xl opacity-50 rounded-full pointer-events-none" />
+        <div className="absolute bottom-0 -right-1/4 w-1/2 h-1/2 bg-indigo-600/10 blur-3xl opacity-50 rounded-full pointer-events-none" />
+
+        <div className="flex justify-center items-center pt-10 pb-4 px-6 backdrop-blur-sm bg-slate-900/20 border-b border-slate-700/20 flex-shrink-0 relative">
+          <h2 className="text-3xl font-bold text-yellow-400 tracking-wide drop-shadow-lg text-center">
+            {t('instructionsModal.title')}
+          </h2>
+          <button onClick={onClose} className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-300 hover:text-slate-100" title={t('instructionsModal.closeButton')}>
+            <HiOutlineXMark className="w-6 h-6" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto min-h-0 p-4 sm:p-6 space-y-6">
+          <p className="text-sm text-slate-300">{t('instructionsModal.closeText')}</p>
+
+          <section className="space-y-2">
+            <h3 className="text-xl font-semibold text-yellow-300">{t('instructionsModal.playerBarTitle')}</h3>
+            <ul className="list-disc list-inside space-y-1 text-slate-300">
+              <li>{t('instructionsModal.playerBar.selectPlayer')}</li>
+              <li>{t('instructionsModal.playerBar.deselectPlayer')}</li>
+              <li>{t('instructionsModal.playerBar.renamePlayer')}</li>
+              <li>{t('instructionsModal.playerBar.renameTeam')}</li>
+              <li>{t('instructionsModal.playerBar.scrollBar')}</li>
+            </ul>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-xl font-semibold text-yellow-300">{t('instructionsModal.fieldAreaTitle')}</h3>
+            <ul className="list-disc list-inside space-y-1 text-slate-300">
+              <li>{t('instructionsModal.fieldArea.movePlayer')}</li>
+              <li>{t('instructionsModal.fieldArea.addPlacePlayer')}</li>
+              <li>{t('instructionsModal.fieldArea.removePlayer')}</li>
+              <li>{t('instructionsModal.fieldArea.drawLines')}</li>
+            </ul>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-xl font-semibold text-yellow-300">{t('instructionsModal.controlBarTitle')}</h3>
+            <ul className="list-disc list-inside space-y-1 text-slate-300">
+              <li>{t('instructionsModal.controlBar.undoRedo')}</li>
+              <li>{t('instructionsModal.controlBar.toggleNames')}</li>
+              <li>{t('instructionsModal.controlBar.placeAllPlayers')}</li>
+              <li>{t('instructionsModal.controlBar.clearDrawings')}</li>
+              <li>{t('instructionsModal.controlBar.addOpponent')}</li>
+              <li>{t('instructionsModal.controlBar.resetField')}</li>
+              <li>{t('instructionsModal.controlBar.toggleTimerOverlay')}</li>
+              <li>{t('instructionsModal.controlBar.timerControls')}</li>
+              <li>{t('instructionsModal.controlBar.help')}</li>
+              <li>{t('instructionsModal.controlBar.fullscreen')}</li>
+              <li>{t('instructionsModal.controlBar.languageToggle')}</li>
+              <li>{t('instructionsModal.controlBar.hardReset')}</li>
+              <li>{t('instructionsModal.controlBar.saveGameAs')}</li>
+              <li>{t('instructionsModal.controlBar.loadGame')}</li>
+            </ul>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-xl font-semibold text-yellow-300">{t('instructionsModal.timerOverlayTitle')}</h3>
+            <ul className="list-disc list-inside space-y-1 text-slate-300">
+              <li>{t('instructionsModal.timerOverlay.setInterval')}</li>
+              <li>{t('instructionsModal.timerOverlay.subAlerts')}</li>
+              <li>{t('instructionsModal.timerOverlay.confirmSub')}</li>
+              <li>{t('instructionsModal.timerOverlay.playTimeHistory')}</li>
+              <li>{t('instructionsModal.timerOverlay.editOpponentNameTitle')}</li>
+            </ul>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-xl font-semibold text-yellow-300">{t('instructionsModal.generalTitle')}</h3>
+            <ul className="list-disc list-inside space-y-1 text-slate-300">
+              <li>{t('instructionsModal.general.touchInteractions')}</li>
+              <li>{t('instructionsModal.general.saving')}</li>
+              <li>{t('instructionsModal.general.fullscreen')}</li>
+            </ul>
+          </section>
+        </div>
+
+        <div className="p-4 border-t border-slate-700/20 backdrop-blur-sm bg-slate-900/20 flex-shrink-0 flex justify-end">
+          <button onClick={onClose} className="px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-md text-sm font-medium transition-colors">
+            {t('instructionsModal.closeButton')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InstructionsModal;

--- a/src/utils/appSettings.test.ts
+++ b/src/utils/appSettings.test.ts
@@ -46,7 +46,8 @@ describe('App Settings Utilities', () => {
       expect(result).toEqual({
         currentGameId: null,
         lastHomeTeamName: '',
-        language: 'en'
+        language: 'en',
+        hasSeenAppGuide: false
       });
     });
 
@@ -60,7 +61,8 @@ describe('App Settings Utilities', () => {
       expect(result).toEqual({
         currentGameId: 'game123',
         lastHomeTeamName: 'Team X',
-        language: 'en' // From default settings
+        language: 'en', // From default settings
+        hasSeenAppGuide: false
       });
     });
 
@@ -74,7 +76,8 @@ describe('App Settings Utilities', () => {
       expect(result).toEqual({
         currentGameId: null,
         lastHomeTeamName: '',
-        language: 'en'
+        language: 'en',
+        hasSeenAppGuide: false
       });
       
       consoleSpy.mockRestore();
@@ -91,7 +94,8 @@ describe('App Settings Utilities', () => {
       expect(result).toEqual({
         currentGameId: null,
         lastHomeTeamName: '',
-        language: 'en'
+        language: 'en',
+        hasSeenAppGuide: false
       });
       consoleSpy.mockRestore();
     });
@@ -133,7 +137,8 @@ describe('App Settings Utilities', () => {
       const currentSettings: AppSettings = {
         currentGameId: 'game123',
         lastHomeTeamName: 'Team A',
-        language: 'en'
+        language: 'en',
+        hasSeenAppGuide: false
       };
       localStorageMock.getItem.mockReturnValue(JSON.stringify(currentSettings));
       
@@ -142,7 +147,8 @@ describe('App Settings Utilities', () => {
       expect(result).toEqual({
         currentGameId: 'game456', // Updated
         lastHomeTeamName: 'Team A', // Preserved
-        language: 'en' // Preserved
+        language: 'en', // Preserved
+        hasSeenAppGuide: false
       });
       
       expect(localStorageMock.setItem).toHaveBeenCalledWith(
@@ -150,7 +156,8 @@ describe('App Settings Utilities', () => {
         JSON.stringify({
           currentGameId: 'game456',
           lastHomeTeamName: 'Team A',
-          language: 'en'
+          language: 'en',
+          hasSeenAppGuide: false
         })
       );
     });
@@ -206,7 +213,8 @@ describe('App Settings Utilities', () => {
       const currentSettings: AppSettings = {
         currentGameId: 'oldGameId',
         lastHomeTeamName: 'Team B',
-        language: 'fi'
+        language: 'fi',
+        hasSeenAppGuide: false
       };
       localStorageMock.getItem.mockReturnValue(JSON.stringify(currentSettings));
       // Mock setItem to simulate successful save by updateAppSettings
@@ -217,9 +225,10 @@ describe('App Settings Utilities', () => {
       expect(localStorageMock.setItem).toHaveBeenCalledWith(
         APP_SETTINGS_KEY,
         JSON.stringify({
-          currentGameId: 'newGameId', 
-          lastHomeTeamName: 'Team B', 
-          language: 'fi' 
+          currentGameId: 'newGameId',
+          lastHomeTeamName: 'Team B',
+          language: 'fi',
+          hasSeenAppGuide: false
         })
       );
       expect(result).toBe(true);
@@ -284,7 +293,8 @@ describe('App Settings Utilities', () => {
       const currentSettings: AppSettings = {
         currentGameId: 'game123',
         lastHomeTeamName: 'Old Team Name',
-        language: 'en'
+        language: 'en',
+        hasSeenAppGuide: false
       };
       localStorageMock.getItem.mockReturnValue(JSON.stringify(currentSettings)); // For getAppSettings call in updateAppSettings
       localStorageMock.setItem.mockImplementation(() => {}); // Default successful save
@@ -337,7 +347,8 @@ describe('App Settings Utilities', () => {
         JSON.stringify({
           currentGameId: null,
           lastHomeTeamName: '',
-          language: 'en'
+          language: 'en',
+          hasSeenAppGuide: false
         })
       );
       expect(result).toBe(true);

--- a/src/utils/appSettings.ts
+++ b/src/utils/appSettings.ts
@@ -19,6 +19,7 @@ export interface AppSettings {
   currentGameId: string | null;
   lastHomeTeamName?: string;
   language?: string;
+  hasSeenAppGuide?: boolean;
   // Add other settings as needed
 }
 
@@ -29,6 +30,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   currentGameId: null,
   lastHomeTeamName: '',
   language: 'en',
+  hasSeenAppGuide: false,
 };
 
 /**
@@ -150,6 +152,29 @@ export const saveLastHomeTeamName = async (teamName: string): Promise<boolean> =
     return true;
   } catch (error) {
     logger.error('Error saving last home team name:', error);
+    return false;
+  }
+};
+
+/**
+ * Gets whether the user has seen the app guide
+ * @returns A promise that resolves to true if seen, false otherwise
+ */
+export const getHasSeenAppGuide = async (): Promise<boolean> => {
+  const settings = await getAppSettings();
+  return settings.hasSeenAppGuide ?? false;
+};
+
+/**
+ * Saves the hasSeenAppGuide flag
+ * @param value - Whether the guide has been viewed
+ * @returns A promise that resolves to true if successful, false otherwise
+ */
+export const saveHasSeenAppGuide = async (value: boolean): Promise<boolean> => {
+  try {
+    await updateAppSettings({ hasSeenAppGuide: value });
+    return true;
+  } catch {
     return false;
   }
 };


### PR DESCRIPTION
## Summary
- implement `InstructionsModal` component styled per the project style guide
- persist `hasSeenAppGuide` in app settings
- show the app guide once on first load
- add toggle button in `ControlBar`
- update tests for new app settings property

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687000a5675c832c82426cdc98484115