### PR TITLE
Move dropdown settings to modal

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -524,6 +524,7 @@
     "languageLabel": "Language",
     "defaultTeamNameLabel": "Default Team Name",
     "resetGuideButton": "Reset App Guide",
+    "hardResetButton": "Hard Reset App",
     "doneButton": "Done"
   },
   "playerStats": {

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -516,6 +516,7 @@
     "languageLabel": "Kieli",
     "defaultTeamNameLabel": "Oletusjoukkueen nimi",
     "resetGuideButton": "Näytä opastus uudelleen",
+    "hardResetButton": "Nollaa Sovellus",
     "doneButton": "Valmis"
   },
   "playerStats": {

--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -11,13 +11,11 @@ import {
     HiOutlineClock,
     HiOutlineClipboardDocumentList, // Replaces FaClipboardList
     HiOutlineClipboard, // Icon for Tactics Board
-    HiOutlineLanguage,
     HiOutlineCog6Tooth, // Settings icon
     HiOutlineBookOpen, // Import for Training Resources
     HiOutlineArrowTopRightOnSquare, // External link icon
     HiOutlineChevronRight, // Chevron for submenu
     HiOutlineChevronLeft, // Chevron for Back button
-    HiOutlineExclamationTriangle, // Icon for Hard Reset
     HiOutlineQuestionMarkCircle, // Icon for rules
     HiOutlinePlusCircle, // Icon for adding discs
     // HiOutlineMinusCircle, // Icon for adding opponent discs
@@ -55,7 +53,6 @@ interface ControlBarProps {
   onToggleTrainingResources: () => void; // Add prop for training modal
   onToggleGoalLogModal: () => void; // Add prop for goal modal
   onToggleGameStatsModal: () => void;
-  onHardResetApp: () => void; // Add the new prop type
   onOpenLoadGameModal: () => void; // NEW PROP
   onStartNewGame: () => void; // CHANGED from onResetGameStats
   onOpenRosterModal: () => void; // Add prop for opening roster modal
@@ -65,7 +62,6 @@ interface ControlBarProps {
   onPlaceAllPlayers: () => void; // New prop for placing all players on the field
   highlightRosterButton: boolean; // <<< ADD prop for highlighting
   onOpenSeasonTournamentModal: () => void;
-  onOpenSettingsModal: () => void;
   isTacticsBoardView: boolean;
   onToggleTacticsBoard: () => void;
   onAddHomeDisc: () => void;
@@ -86,7 +82,6 @@ const ControlBar: React.FC<ControlBarProps> = ({
   onToggleTrainingResources,
   onToggleGoalLogModal,
   onToggleGameStatsModal,
-  onHardResetApp,
   onOpenLoadGameModal,
   onStartNewGame,
   onOpenRosterModal,
@@ -96,14 +91,13 @@ const ControlBar: React.FC<ControlBarProps> = ({
   onPlaceAllPlayers,
   highlightRosterButton, // <<< Receive prop
   onOpenSeasonTournamentModal,
-  onOpenSettingsModal,
   isTacticsBoardView,
   onToggleTacticsBoard,
   onAddHomeDisc,
   onAddOpponentDisc,
   onToggleInstructionsModal,
 }) => {
-  const { t, i18n } = useTranslation(); // Standard hook
+  const { t } = useTranslation(); // Standard hook
   logger.log('[ControlBar Render] Received highlightRosterButton prop:', highlightRosterButton); // <<< Log prop value
   const [isSettingsMenuOpen, setIsSettingsMenuOpen] = useState(false);
   const [menuView, setMenuView] = useState<'main' | 'tulospalvelu'>('main'); // NEW state for menu view
@@ -120,13 +114,6 @@ const ControlBar: React.FC<ControlBarProps> = ({
   const logGoalColor = "bg-blue-600 hover:bg-blue-500 focus:ring-blue-500"; 
   // --- END RE-ADD BUTTON STYLES --- 
 
-  const handleLanguageToggle = () => {
-    const nextLang = i18n.language === 'en' ? 'fi' : 'en';
-    i18n.changeLanguage(nextLang);
-    logger.log(`Changed language to ${nextLang}`);
-    setIsSettingsMenuOpen(false); // Close menu after action
-    setMenuView('main'); 
-  };
 
   const handleSettingsButtonClick = () => {
     setIsSettingsMenuOpen(!isSettingsMenuOpen);
@@ -381,21 +368,7 @@ const ControlBar: React.FC<ControlBarProps> = ({
                        {/* ADD Subtle Divider - slightly more visible */}
                        <hr className="border-slate-600/40 my-1 mx-2" />
                        
-                       {/* Group 5: Settings & Actions (Revised) */}
-                       <div className="py-0.5">
-                         {/* Language Toggle - Fix translation */}
-                       <button onClick={handleLanguageToggle} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                         <HiOutlineLanguage className={menuIconSize} />
-                         {t('controlBar.toggleLanguage', i18n.language === 'en' ? 'Switch to Finnish' : 'Vaihda Englantiin')} ({i18n.language === 'en' ? 'FI' : 'EN'})
-                       </button>
-                        <button onClick={wrapHandler(onOpenSettingsModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                          <HiOutlineCog6Tooth className={menuIconSize} /> {t('controlBar.appSettings', 'App Settings')}
-                        </button>
-                        {/* Hard Reset */}
-                         <button onClick={wrapHandler(onHardResetApp)} className="w-full flex items-center px-3 py-1.5 text-sm text-red-400 hover:bg-red-900/50">
-                           <HiOutlineExclamationTriangle className={menuIconSize} /> {t('controlBar.hardReset', 'Hard Reset App')}
-                         </button>
-                       </div>
+                      {/* Group 5 removed: Language toggle, app settings, hard reset now live in SettingsModal */}
                      </nav>
                    </div>{/* End Main Menu View */}
 

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1814,10 +1814,6 @@ function HomePage() {
   const handleCloseGameSettingsModal = () => {
     setIsGameSettingsModalOpen(false); // Corrected State Setter
   };
-
-  const handleOpenSettingsModal = () => {
-    setIsSettingsModalOpen(true);
-  };
   const handleCloseSettingsModal = () => {
     setIsSettingsModalOpen(false);
   };
@@ -2379,13 +2375,11 @@ function HomePage() {
           onToggleTrainingResources={handleToggleTrainingResources}
           onToggleGoalLogModal={handleToggleGoalLogModal}
           onToggleGameStatsModal={handleToggleGameStatsModal}
-          onHardResetApp={handleHardResetApp}
           onOpenLoadGameModal={handleOpenLoadGameModal}
           onStartNewGame={handleStartNewGame}
           onOpenRosterModal={openRosterModal}
           onQuickSave={handleQuickSaveGame}
           onOpenGameSettingsModal={handleOpenGameSettingsModal}
-          onOpenSettingsModal={handleOpenSettingsModal}
           isGameLoaded={!!currentGameId && currentGameId !== DEFAULT_GAME_ID}
           onPlaceAllPlayers={handlePlaceAllPlayers}
           highlightRosterButton={highlightRosterButton}
@@ -2578,6 +2572,7 @@ function HomePage() {
         onResetGuide={() => {
           saveHasSeenAppGuide(false);
         }}
+        onHardResetApp={handleHardResetApp}
       />
     </main>
   );

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -18,6 +18,7 @@ const defaultProps = {
   defaultTeamName: 'My Team',
   onDefaultTeamNameChange: jest.fn(),
   onResetGuide: jest.fn(),
+  onHardResetApp: jest.fn(),
 };
 
 describe('<SettingsModal />', () => {
@@ -36,5 +37,11 @@ describe('<SettingsModal />', () => {
     render(<SettingsModal {...defaultProps} />);
     fireEvent.click(screen.getByRole('button', { name: /Done/i }));
     expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  test('calls onHardResetApp when Hard Reset button clicked', () => {
+    render(<SettingsModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Hard Reset App/i }));
+    expect(defaultProps.onHardResetApp).toHaveBeenCalled();
   });
 });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ interface SettingsModalProps {
   defaultTeamName: string;
   onDefaultTeamNameChange: (name: string) => void;
   onResetGuide: () => void;
+  onHardResetApp: () => void;
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -21,6 +22,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   defaultTeamName,
   onDefaultTeamNameChange,
   onResetGuide,
+  onHardResetApp,
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -49,6 +51,8 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
     'px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed';
   const primaryButtonStyle =
     `${buttonStyle} bg-gradient-to-b from-indigo-500 to-indigo-600 text-white hover:from-indigo-600 hover:to-indigo-700 shadow-lg`;
+  const dangerButtonStyle =
+    `${buttonStyle} bg-gradient-to-b from-red-600 to-red-700 text-white hover:from-red-700 hover:to-red-800 shadow-lg`;
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-[60] font-display">
@@ -89,6 +93,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
             </div>
             <button onClick={onResetGuide} className={primaryButtonStyle}>
               {t('settingsModal.resetGuideButton', 'Reset App Guide')}
+            </button>
+            <button onClick={onHardResetApp} className={dangerButtonStyle}>
+              {t('settingsModal.hardResetButton', 'Hard Reset App')}
             </button>
           </div>
           <div className="p-4 border-t border-slate-700/20 backdrop-blur-sm bg-slate-900/20 flex-shrink-0">

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -417,6 +417,7 @@ export type TranslationKey =
   | 'seasonTournamentModal.tournaments'
   | 'settingsModal.defaultTeamNameLabel'
   | 'settingsModal.doneButton'
+  | 'settingsModal.hardResetButton'
   | 'settingsModal.languageLabel'
   | 'settingsModal.resetGuideButton'
   | 'settingsModal.title'


### PR DESCRIPTION
## Summary
- move Hard Reset to SettingsModal and expose a new handler
- remove language toggle and app settings from ControlBar menu
- update English and Finnish locales for settings
- update unit tests and regenerate i18n types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870bb69407c832ca3a9b7a53b70d899