### PR TITLE
Add SettingsModal to control menu

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -67,6 +67,7 @@ interface ControlBarProps {
   onAddHomeDisc: () => void;
   onAddOpponentDisc: () => void;
   onToggleInstructionsModal: () => void;
+  onOpenSettingsModal: () => void;
 }
 
 const ControlBar: React.FC<ControlBarProps> = ({
@@ -96,6 +97,7 @@ const ControlBar: React.FC<ControlBarProps> = ({
   onAddHomeDisc,
   onAddOpponentDisc,
   onToggleInstructionsModal,
+  onOpenSettingsModal,
 }) => {
   const { t } = useTranslation(); // Standard hook
   logger.log('[ControlBar Render] Received highlightRosterButton prop:', highlightRosterButton); // <<< Log prop value
@@ -367,8 +369,14 @@ const ControlBar: React.FC<ControlBarProps> = ({
 
                        {/* ADD Subtle Divider - slightly more visible */}
                        <hr className="border-slate-600/40 my-1 mx-2" />
-                       
-                      {/* Group 5 removed: Language toggle, app settings, hard reset now live in SettingsModal */}
+
+                     {/* Group 5: App Settings */}
+                     <div className="py-0.5">
+                       <button onClick={wrapHandler(onOpenSettingsModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
+                         <HiOutlineCog6Tooth className={menuIconSize} /> {t('controlBar.appSettings', 'App Settings')}
+                       </button>
+                     </div>
+
                      </nav>
                    </div>{/* End Main Menu View */}
 

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1814,6 +1814,9 @@ function HomePage() {
   const handleCloseGameSettingsModal = () => {
     setIsGameSettingsModalOpen(false); // Corrected State Setter
   };
+  const handleOpenSettingsModal = () => {
+    setIsSettingsModalOpen(true);
+  };
   const handleCloseSettingsModal = () => {
     setIsSettingsModalOpen(false);
   };
@@ -2389,6 +2392,7 @@ function HomePage() {
           onAddHomeDisc={() => handleAddTacticalDisc('home')}
           onAddOpponentDisc={() => handleAddTacticalDisc('opponent')}
           onToggleInstructionsModal={handleToggleInstructionsModal}
+          onOpenSettingsModal={handleOpenSettingsModal}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- pass `onOpenSettingsModal` prop through `ControlBar`
- open SettingsModal from the control menu
- wire opening handler in `HomePage`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870e590a734832c807c10a3f5ee98ed