### PR TITLE
Fix settings guide button

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1295,6 +1295,12 @@ function HomePage() {
     setIsInstructionsModalOpen(!isInstructionsModalOpen);
   };
 
+  const handleShowAppGuide = () => {
+    saveHasSeenAppGuide(false);
+    setIsSettingsModalOpen(false);
+    setIsInstructionsModalOpen(true);
+  };
+
   // NEW: Handler for Hard Reset
   const handleHardResetApp = useCallback(async () => {
     if (window.confirm(t('controlBar.hardResetConfirmation', 'Are you sure you want to completely reset the application? All saved data (players, stats, positions) will be permanently lost.'))) {
@@ -2573,9 +2579,7 @@ function HomePage() {
           setDefaultTeamNameSetting(name);
           utilSaveLastHomeTeamName(name);
         }}
-        onResetGuide={() => {
-          saveHasSeenAppGuide(false);
-        }}
+        onResetGuide={handleShowAppGuide}
         onHardResetApp={handleHardResetApp}
       />
     </main>

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -50,4 +50,10 @@ describe('<SettingsModal />', () => {
     fireEvent.click(resetBtn);
     expect(defaultProps.onHardResetApp).toHaveBeenCalled();
   });
+
+  test('calls onResetGuide when Reset App Guide clicked', () => {
+    render(<SettingsModal {...defaultProps} />);
+    fireEvent.click(screen.getByRole('button', { name: /Reset App Guide/i }));
+    expect(defaultProps.onResetGuide).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- open the onboarding guide when clicking the "Reset App Guide" button
- test that the button triggers the handler

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870ff63399c832c8e02347f49d85b15