### PR TITLE
Add totals row for player stats

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -549,6 +549,7 @@
     "points": "Points",
     "seasonPerformance": "Season Performance",
     "tournamentPerformance": "Tournament Performance",
-    "vs": "vs"
+    "vs": "vs",
+    "totalsRow": "Totals"
   }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -541,6 +541,7 @@
     "points": "Pisteet",
     "seasonPerformance": "Kausisuoritus",
     "tournamentPerformance": "Turnaussuoritus",
-    "vs": "vs"
+    "vs": "vs",
+    "totalsRow": "Yhteensä"
   }
 }

--- a/src/components/GameStatsModal.test.tsx
+++ b/src/components/GameStatsModal.test.tsx
@@ -215,6 +215,20 @@ describe('GameStatsModal', () => {
     expect(aliceRow).toHaveTextContent('1');    // Total Points
   });
 
+  test('shows totals row with aggregated stats', async () => {
+    await act(async () => {
+      renderComponent(getDefaultProps());
+    });
+
+    const totalsRow = screen.getByText(i18n.t('playerStats.totalsRow'));
+    const cells = totalsRow.closest('tr')!.querySelectorAll('td');
+    expect(cells[1]).toHaveTextContent('3'); // games played total
+    expect(cells[2]).toHaveTextContent('2'); // goals total
+    expect(cells[3]).toHaveTextContent('1'); // assists total
+    expect(cells[4]).toHaveTextContent('3'); // total score
+    expect(cells[5]).toHaveTextContent('1.0'); // average points
+  });
+
   test('displays game event log correctly', async () => {
     await act(async () => {
       renderComponent(getDefaultProps());

--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -792,6 +792,19 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
     selectedPlayerIds
   ]);
 
+  const totals = useMemo(() => {
+    return playerStats.reduce(
+      (acc, p) => {
+        acc.gamesPlayed += p.gamesPlayed;
+        acc.goals += p.goals;
+        acc.assists += p.assists;
+        acc.totalScore += p.totalScore;
+        return acc;
+      },
+      { gamesPlayed: 0, goals: 0, assists: 0, totalScore: 0 }
+    );
+  }, [playerStats]);
+
   // Use localGameEvents for display
   const sortedGoals = useMemo(() => {
     if (activeTab === 'currentGame') {
@@ -1207,7 +1220,8 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                         </tr>
                       </thead>
                       <tbody className="text-slate-100">
-                         {playerStats.length > 0 ? (playerStats.map(player => (
+                         {playerStats.length > 0 ? (
+                          playerStats.map(player => (
                           <tr key={player.id} className="border-b border-slate-800 hover:bg-slate-800/40 cursor-pointer" onClick={() => handlePlayerRowClick(player)}>
                             <td className="px-2 py-2 font-medium whitespace-nowrap">{player.name}</td>
                             <td className="px-1 py-2 text-center text-yellow-400 font-semibold">{player.gamesPlayed}</td>
@@ -1216,8 +1230,19 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                             <td className="px-1 py-2 text-center text-yellow-400 font-bold">{player.totalScore}</td>
                             <td className="px-1 py-2 text-center text-yellow-400 font-semibold">{player.avgPoints.toFixed(1)}</td>
                           </tr>
-                        ))) : (
+                        ))
+                        ) : (
                           <tr><td colSpan={6} className="py-4 text-center text-slate-400">{t('common.noPlayersMatchFilter', 'Ei pelaajia hakusuodattimella')}</td></tr>
+                        )}
+                        {playerStats.length > 0 && (
+                          <tr className="border-t border-slate-700 bg-slate-800/60 font-semibold">
+                            <td className="px-2 py-2">{t('playerStats.totalsRow', 'Totals')}</td>
+                            <td className="px-1 py-2 text-center text-yellow-400">{totals.gamesPlayed}</td>
+                            <td className="px-1 py-2 text-center text-yellow-400">{totals.goals}</td>
+                            <td className="px-1 py-2 text-center text-yellow-400">{totals.assists}</td>
+                            <td className="px-1 py-2 text-center text-yellow-400 font-bold">{totals.totalScore}</td>
+                            <td className="px-1 py-2 text-center text-yellow-400">{(totals.gamesPlayed > 0 ? (totals.totalScore / totals.gamesPlayed).toFixed(1) : '0.0')}</td>
+                          </tr>
                         )}
                       </tbody>
                     </table>

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -387,6 +387,7 @@ export type TranslationKey =
   | 'playerStats.selectPlayer'
   | 'playerStats.selectPlayerLabel'
   | 'playerStats.title'
+  | 'playerStats.totalsRow'
   | 'playerStats.tournamentPerformance'
   | 'playerStats.vs'
   | 'rosterSettingsModal.addNewPlayerTitle'

--- a/src/i18n.test.ts
+++ b/src/i18n.test.ts
@@ -43,6 +43,7 @@ const testResources = {
       "common.opponentGoal": "Opponent Goal",
       "common.assist": "Assist: {{player}}",
       "common.notSet": "Not Set",
+      "playerStats.totalsRow": "Totals"
       // Add any other keys used in GameStatsModal or its tests
     }
   },
@@ -61,9 +62,9 @@ const testResources = {
       "gameStatsModal.editGoalTooltip": "Muokkaa Maalia",
       "gameStatsModal.deleteGoalTooltip": "Poista Maali",
       "gameStatsModal.saveGoalTooltip": "Tallenna Maali",
-      "gameStatsModal.cancelEditGoalTooltip": "Peruuta Muokkaus", "gameStatsModal.confirmDeleteEvent": "Haluatko varmasti poistaa t�m�n tapahtuman?",
+      "gameStatsModal.cancelEditGoalTooltip": "Peruuta Muokkaus", "gameStatsModal.confirmDeleteEvent": "Haluatko varmasti poistaa tämän tapahtuman?",
       "common.opponent": "Vastustaja",
-      "common.date": "Päivämäärä",
+      "common.date": "PÃ¤ivÃ¤mÃ¤Ã¤rÃ¤",
       "common.location": "Paikka",
       "common.time": "Aika",
       "common.home": "Koti",
@@ -83,8 +84,9 @@ const testResources = {
       "common.fp": "FP",
       "common.goal": "Maali",
       "common.opponentGoal": "Vastustajan Maali",
-      "common.assist": "Syöttäjä: {{player}}",
+      "common.assist": "SyÃ¶ttÃ¤jÃ¤: {{player}}",
       "common.notSet": "Ei asetettu",
+      "playerStats.totalsRow": "Yhteensä",
     }
   },
   // Add other languages if needed for specific tests


### PR DESCRIPTION
## Summary
- implement totals row in `GameStatsModal`
- add translations for `playerStats.totalsRow`
- adjust tests to cover new totals row
- regenerate i18n types

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870ff2cb12c832ca5eb853f09efa03a