### PR TITLE
Remove manual testing content from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,18 +89,6 @@ The tests rely on [Jest](https://jestjs.io/) and [React Testing Library](https:/
 *   **Data Storage:** All your data is stored in your browser's `localStorage`. This is fast and enables offline use, but it means clearing your browser data will erase everything. **Use the "Full Backup" feature regularly!**
 *   **Offline Use:** To get the best experience, install the app on your device when prompted by your browser ("Add to Home Screen" on mobile, or an install icon in the address bar on desktop).
 
-### Manual Testing Checklist
-
-1. Start the development server with `npm run dev` and perform a quick save from the home page. A green toast should appear confirming the save.
-2. Disable localStorage in your browser tools and attempt to save a game; an error should be logged but the app must not crash.
-3. Trigger the language switcher and verify all labels update without page reloads.
-4. Start the game timer and ensure it continues counting even when switching views or modals.
-5. Use the backup export feature and verify a file downloads with your saved games.
-6. Run `npm run generate:i18n-types` and ensure `src/i18n-types.ts` is updated without errors.
-7. Switch the language selector between English and Finnish and confirm all text updates immediately.
-8. Build the project with `npm run build` and open the production build to verify no missing translation warnings appear.
-9. Review the additional [Manual Testing Guide](./MANUAL_TESTING.md) for steps covering score updates, timer resets and modal interactions.
-
 ---
 
 *This project is under active development. Feel free to contribute or report issues!**


### PR DESCRIPTION
## Summary
- remove the manual testing checklist from the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871281d5474832ca3986e6b9cbde49d