### PR TITLE
Improve storage usage units

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -52,6 +52,15 @@ describe('<SettingsModal />', () => {
     expect(await screen.findByText(/1\.0 MB.*5\.0 MB/)).toBeInTheDocument();
   });
 
+  test('displays usage in KB when below 1 MB', async () => {
+    (navigator.storage.estimate as jest.Mock).mockResolvedValueOnce({
+      usage: 512 * 1024,
+      quota: 2 * 1048576,
+    });
+    render(<SettingsModal {...defaultProps} />);
+    expect(await screen.findByText(/512\.0 KB.*2\.0 MB/)).toBeInTheDocument();
+  });
+
   test('calls onClose when Done clicked', () => {
     render(<SettingsModal {...defaultProps} />);
     fireEvent.click(screen.getByRole('button', { name: /Done/i }));

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { formatBytes } from '@/utils/bytes';
 import packageJson from '../../package.json';
 
 interface SettingsModalProps {
@@ -111,17 +112,17 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               </p>
               <div className="space-y-1">
                 <label className={labelStyle}>{t('settingsModal.storageUsageLabel', 'Storage Usage')}</label>
-                <p className="text-sm text-slate-300">
-                  {storageEstimate
-                    ? t('settingsModal.storageUsageDetails', {
-                        used: `${(storageEstimate.usage / 1048576).toFixed(1)} MB`,
-                        quota: `${(storageEstimate.quota / 1048576).toFixed(1)} MB`,
-                      })
-                    : t(
-                        'settingsModal.storageUsageUnavailable',
-                        'Storage usage information unavailable.'
-                      )}
-                </p>
+                  <p className="text-sm text-slate-300">
+                    {storageEstimate
+                      ? t('settingsModal.storageUsageDetails', {
+                          used: formatBytes(storageEstimate.usage),
+                          quota: formatBytes(storageEstimate.quota),
+                        })
+                      : t(
+                          'settingsModal.storageUsageUnavailable',
+                          'Storage usage information unavailable.'
+                        )}
+                  </p>
                 {storageEstimate && (
                   <div className="w-full bg-slate-700 rounded-md h-2 overflow-hidden">
                     <div

--- a/src/utils/bytes.test.ts
+++ b/src/utils/bytes.test.ts
@@ -1,0 +1,10 @@
+import { formatBytes } from './bytes';
+
+describe('formatBytes', () => {
+  it('formats bytes to appropriate units', () => {
+    expect(formatBytes(500)).toBe('500 B');
+    expect(formatBytes(1024)).toBe('1.0 KB');
+    expect(formatBytes(1048576)).toBe('1.0 MB');
+    expect(formatBytes(1073741824)).toBe('1.0 GB');
+  });
+});

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,9 @@
+export const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  const gb = mb / 1024;
+  return `${gb.toFixed(1)} GB`;
+};


### PR DESCRIPTION
## Summary
- add `formatBytes` utility to display bytes with KB/MB/GB units
- show settings modal storage usage using `formatBytes`
- test storage usage in KB
- cover `formatBytes` utility with unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68713c9b7d44832cb623441c4e2ec24c