### PR TITLE
Limit storage bar to 5 MB

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -58,7 +58,7 @@ describe('<SettingsModal />', () => {
       quota: 2 * 1048576,
     });
     render(<SettingsModal {...defaultProps} />);
-    expect(await screen.findByText(/512\.0 KB.*2\.0 MB/)).toBeInTheDocument();
+    expect(await screen.findByText(/512\.0 KB.*5\.0 MB/)).toBeInTheDocument();
   });
 
   test('calls onClose when Done clicked', () => {

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -31,6 +31,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   const [teamName, setTeamName] = useState(defaultTeamName);
   const [resetConfirm, setResetConfirm] = useState('');
   const [storageEstimate, setStorageEstimate] = useState<{ usage: number; quota: number } | null>(null);
+  const MAX_LOCAL_STORAGE = 5 * 1024 * 1024; // 5 MB assumption for localStorage
 
   useEffect(() => {
     setTeamName(defaultTeamName);
@@ -42,13 +43,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
       if (navigator.storage?.estimate) {
         navigator.storage
           .estimate()
-          .then(res => setStorageEstimate({ usage: res.usage || 0, quota: res.quota || 0 }))
+          .then(res =>
+            setStorageEstimate({ usage: res.usage || 0, quota: MAX_LOCAL_STORAGE })
+          )
           .catch(() => setStorageEstimate(null));
       } else {
         setStorageEstimate(null);
       }
     }
-  }, [isOpen]);
+  }, [isOpen, MAX_LOCAL_STORAGE]);
 
   if (!isOpen) return null;
 
@@ -116,7 +119,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                     {storageEstimate
                       ? t('settingsModal.storageUsageDetails', {
                           used: formatBytes(storageEstimate.usage),
-                          quota: formatBytes(storageEstimate.quota),
+                          quota: formatBytes(MAX_LOCAL_STORAGE),
                         })
                       : t(
                           'settingsModal.storageUsageUnavailable',
@@ -127,7 +130,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                   <div className="w-full bg-slate-700 rounded-md h-2 overflow-hidden">
                     <div
                       className="bg-indigo-500 h-2"
-                      style={{ width: `${Math.min(100, (storageEstimate.usage / storageEstimate.quota) * 100)}%` }}
+                      style={{ width: `${Math.min(100, (storageEstimate.usage / MAX_LOCAL_STORAGE) * 100)}%` }}
                     />
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- hard-code storage quota to 5MB in SettingsModal
- update progress bar logic and tests accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68714110f348832c83a2c4200fdca117