### PR TITLE
Improve release notes summary

### DIFF
--- a/scripts/generate-release-notes.mjs
+++ b/scripts/generate-release-notes.mjs
@@ -3,7 +3,21 @@ import { writeFileSync, readFileSync } from 'fs';
 
 function getLastCommitMessage() {
   try {
-    return execSync('git log -1 --format=%B').toString().trim();
+    const full = execSync('git log -1 --format=%B').toString().trim();
+    const lines = full
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean);
+
+    if (lines.length === 0) {
+      return '';
+    }
+
+    if (lines[0].startsWith('Merge pull request')) {
+      return lines[lines.length - 1];
+    }
+
+    return lines[0];
   } catch (err) {
     console.error('Failed to get commit message', err);
     return '';


### PR DESCRIPTION
## Summary
- adjust generate-release-notes.mjs to strip merge metadata and return a concise summary

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871490d1874832c9477960cdedb60e1