### PR TITLE
Implement assessment UI components

### DIFF
--- a/.docs/player-assessment-feature-plan.md
+++ b/.docs/player-assessment-feature-plan.md
@@ -53,7 +53,7 @@
 ## 8. Incremental Delivery Steps
 1. **Data layer** – implement `PlayerAssessment` type, AppState updates and Firestore helpers. ✅
 2. **Modal skeleton** – create modal component with simple Save per player, using dummy sliders. ✅
-3. **UI components** – build sliders and rating selector, integrate into cards.
+3. **UI components** – build sliders and rating selector, integrate into cards. ✅
 4. **Persistence** – wire up `updateDoc` and local state with validation.
 5. **Statistics integration** – display averages in PlayerStatsView and GameStatsModal.
 6. **Polish & translations** – finalize tooltips, accessibility labels and translation keys.

--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -8,5 +8,6 @@ Use this short checklist to manually verify key workflows after making changes t
 4. **Switch languages** – Toggle between English and Finnish and verify all visible text changes without reloading the page.
 5. **Save and reload a game** – Perform a quick save, refresh the page and load the saved game to confirm state persistence.
 6. **Assess players after a game** – After ending a game, open the Player Assessment modal via the new button. Adjust a slider for a player, tap **Save**, then close and reopen the modal to confirm the rating was stored.
+7. **Try new assessment UI** – Expand a player card and verify the segmented overall selector, sliders and notes input work. Saving should collapse the card and show a checkmark.
 
 Running through these steps after updates helps catch regressions before deploying.

--- a/src/components/AssessmentSlider.test.tsx
+++ b/src/components/AssessmentSlider.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AssessmentSlider from './AssessmentSlider';
+
+describe('AssessmentSlider', () => {
+  it('calls onChange with the slider value', () => {
+    const onChange = jest.fn();
+    render(<AssessmentSlider label="test" value={3} onChange={onChange} />);
+    fireEvent.change(screen.getByRole('slider'), { target: { value: '4' } });
+    expect(onChange).toHaveBeenCalledWith(4);
+  });
+});

--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import React from 'react';
+
+interface AssessmentSliderProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onChange }) => {
+  return (
+    <div className="flex flex-col items-center space-y-1">
+      <input
+        type="range"
+        min={1}
+        max={5}
+        step={0.5}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="appearance-none h-32 w-1 bg-indigo-600/70 rounded-full rotate-[-90deg]"
+      />
+      <span className="text-xs text-slate-300">{label}</span>
+    </div>
+  );
+};
+
+export default AssessmentSlider;

--- a/src/components/OverallRatingSelector.test.tsx
+++ b/src/components/OverallRatingSelector.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import OverallRatingSelector from './OverallRatingSelector';
+
+describe('OverallRatingSelector', () => {
+  it('calls onChange when a button is clicked', () => {
+    const onChange = jest.fn();
+    render(<OverallRatingSelector value={5} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: '3' }));
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+});

--- a/src/components/OverallRatingSelector.tsx
+++ b/src/components/OverallRatingSelector.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+
+interface OverallRatingSelectorProps {
+  value: number;
+  onChange: (value: number) => void;
+}
+
+const OverallRatingSelector: React.FC<OverallRatingSelectorProps> = ({ value, onChange }) => {
+  const numbers = Array.from({ length: 10 }, (_, i) => i + 1);
+  return (
+    <div className="flex space-x-1">
+      {numbers.map((n) => (
+        <button
+          key={n}
+          type="button"
+          aria-label={n.toString()}
+          className={`px-2 py-1 rounded-md text-sm font-medium transition-colors ${
+            value === n
+              ? 'bg-indigo-600 text-white'
+              : 'bg-slate-800/40 text-slate-300 hover:bg-slate-800/60'
+          }`}
+          onClick={() => onChange(n)}
+        >
+          {n}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default OverallRatingSelector;

--- a/src/components/PlayerAssessmentCard.test.tsx
+++ b/src/components/PlayerAssessmentCard.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PlayerAssessmentCard from './PlayerAssessmentCard';
+import type { Player } from '@/types';
+
+describe('PlayerAssessmentCard', () => {
+  const player: Player = { id: 'p1', name: 'Test', jerseyNumber: '9' };
+
+  it('renders player name', () => {
+    render(<PlayerAssessmentCard player={player} onSave={jest.fn()} />);
+    expect(screen.getByText('Test #9')).toBeInTheDocument();
+  });
+
+  it('calls onSave with assessment', () => {
+    const onSave = jest.fn();
+    render(<PlayerAssessmentCard player={player} onSave={onSave} />);
+    fireEvent.click(screen.getByText('Test #9'));
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+    expect(onSave).toHaveBeenCalled();
+  });
+});

--- a/src/components/PlayerAssessmentCard.tsx
+++ b/src/components/PlayerAssessmentCard.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useState } from 'react';
+import { HiCheckCircle, HiXCircle } from 'react-icons/hi';
+import type { Player, PlayerAssessment } from '@/types';
+import OverallRatingSelector from './OverallRatingSelector';
+import AssessmentSlider from './AssessmentSlider';
+
+interface PlayerAssessmentCardProps {
+  player: Player;
+  onSave: (assessment: Partial<PlayerAssessment>) => void;
+}
+
+const initialSliders = {
+  intensity: 3,
+  courage: 3,
+  duels: 3,
+  technique: 3,
+  creativity: 3,
+  decisions: 3,
+  awareness: 3,
+  teamwork: 3,
+  fair_play: 3,
+  impact: 3,
+};
+
+const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onSave }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [overall, setOverall] = useState<number>(5);
+  const [sliders, setSliders] = useState<Record<string, number>>(initialSliders);
+  const [notes, setNotes] = useState('');
+  const isValid = notes.length <= 280;
+
+  const handleSliderChange = (key: string, value: number) => {
+    setSliders((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({
+      overall,
+      sliders: sliders as PlayerAssessment['sliders'],
+      notes,
+    });
+    setExpanded(false);
+  };
+
+  return (
+    <div className="p-2 rounded-md border bg-slate-800/40 border-slate-700/50 hover:bg-slate-800/60 transition-colors text-slate-100">
+      <div className="flex items-center justify-between" onClick={() => setExpanded((v) => !v)}>
+        <span className="font-semibold">
+          {player.name}
+          {player.jerseyNumber ? ` #${player.jerseyNumber}` : ''}
+        </span>
+        {expanded ? <HiCheckCircle className="text-indigo-400" /> : <HiXCircle className="text-slate-500" />}
+      </div>
+      {expanded && (
+        <div className="mt-2 space-y-3">
+          <OverallRatingSelector value={overall} onChange={setOverall} />
+          <div className="grid grid-cols-5 gap-2">
+            {Object.entries(sliders).map(([key, value]) => (
+              <AssessmentSlider
+                key={key}
+                label={key}
+                value={value}
+                onChange={(v) => handleSliderChange(key, v)}
+              />
+            ))}
+          </div>
+          <div>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              maxLength={280}
+              className="w-full bg-slate-700 border border-slate-600 rounded-md text-white p-2"
+              rows={3}
+            />
+            <div className="text-xs text-slate-400 text-right">{notes.length}/280</div>
+          </div>
+          <button
+            type="button"
+            className="px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50"
+            onClick={handleSave}
+            disabled={!isValid}
+          >
+            Save
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlayerAssessmentCard;

--- a/src/components/PlayerAssessmentModal.test.tsx
+++ b/src/components/PlayerAssessmentModal.test.tsx
@@ -36,7 +36,8 @@ describe('PlayerAssessmentModal', () => {
   it('calls onSave when save button clicked', () => {
     const onSave = jest.fn();
     renderModal({ onSave });
+    fireEvent.click(screen.getByText('Player One #10'));
     fireEvent.click(screen.getByRole('button', { name: /Save/i }));
-    expect(onSave).toHaveBeenCalledWith('p1', { overall: 3 });
+    expect(onSave).toHaveBeenCalled();
   });
 });

--- a/src/components/PlayerAssessmentModal.tsx
+++ b/src/components/PlayerAssessmentModal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Player, PlayerAssessment } from '@/types';
+import PlayerAssessmentCard from './PlayerAssessmentCard';
 
 interface PlayerAssessmentModalProps {
   isOpen: boolean;
@@ -20,7 +21,6 @@ const PlayerAssessmentModal: React.FC<PlayerAssessmentModalProps> = ({
   onSave,
 }) => {
   const { t } = useTranslation();
-  const [ratings, setRatings] = useState<Record<string, number>>({});
 
   if (!isOpen) return null;
 
@@ -34,11 +34,6 @@ const PlayerAssessmentModal: React.FC<PlayerAssessmentModalProps> = ({
     `${buttonBaseStyle} bg-gradient-to-b from-indigo-500 to-indigo-600 text-white hover:from-indigo-600 hover:to-indigo-700 shadow-lg`;
 
   const getPlayer = (id: string) => availablePlayers.find(p => p.id === id);
-
-  const handleSave = (playerId: string) => {
-    const overall = ratings[playerId] ?? 3;
-    onSave(playerId, { overall });
-  };
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-[60] font-display">
@@ -56,23 +51,11 @@ const PlayerAssessmentModal: React.FC<PlayerAssessmentModalProps> = ({
               const player = getPlayer(pid);
               if (!player) return null;
               return (
-                <div key={pid} className="p-2 rounded-md border bg-slate-800/40 border-slate-700/50 hover:bg-slate-800/60 transition-colors">
-                  <div className="flex items-center justify-between mb-2 text-slate-100">
-                    <span>{player.name}{player.jerseyNumber ? ` #${player.jerseyNumber}` : ''}</span>
-                  </div>
-                  <input
-                    type="range"
-                    min={1}
-                    max={5}
-                    step={1}
-                    value={ratings[pid] ?? 3}
-                    onChange={e => setRatings(prev => ({ ...prev, [pid]: Number(e.target.value) }))}
-                    className="w-full"
-                  />
-                  <button onClick={() => handleSave(pid)} className={`${primaryButtonStyle} mt-2`}>
-                    {t('playerAssessmentModal.saveButton', 'Save')}
-                  </button>
-                </div>
+                <PlayerAssessmentCard
+                  key={pid}
+                  player={player}
+                  onSave={(assessment) => onSave(pid, assessment)}
+                />
               );
             })}
             {selectedPlayerIds.length === 0 && (


### PR DESCRIPTION
## Summary
- build OverallRatingSelector and AssessmentSlider
- create PlayerAssessmentCard for per-player rating
- integrate new components into PlayerAssessmentModal
- update unit tests
- document manual testing for the new UI
- mark UI component step complete in the feature plan

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717bd44b54832caacdc3b925bf565a