### PR TITLE
Fix player assessment slider rotation

### DIFF
--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -18,7 +18,7 @@ const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onCha
         step={0.5}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="appearance-none h-32 w-1 bg-indigo-600/70 rounded-full rotate-[-90deg]"
+        className="appearance-none h-32 w-1 bg-indigo-600/70 rounded-full -rotate-90"
       />
       <span className="text-xs text-slate-300">{label}</span>
     </div>


### PR DESCRIPTION
## Summary
- make AssessmentSlider use valid Tailwind negative rotation class

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687186db4810832c81c5d29bd855ba3a