### PR TITLE
Improve player assessment sliders

### DIFF
--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -10,17 +10,18 @@ interface AssessmentSliderProps {
 
 const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onChange }) => {
   return (
-    <div className="flex flex-col items-center space-y-1">
+    <div className="flex items-center space-x-2 w-full">
+      <label className="text-sm text-slate-300 w-24 shrink-0">{label}</label>
       <input
         type="range"
         min={1}
         max={5}
-        step={0.5}
+        step={1}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        className="appearance-none h-32 w-1 bg-indigo-600/70 rounded-full -rotate-90"
+        className="flex-1 h-2 rounded-lg appearance-none cursor-pointer bg-slate-600 accent-indigo-600"
       />
-      <span className="text-xs text-slate-300">{label}</span>
+      <span className="text-sm text-yellow-400 w-6 text-right">{value}</span>
     </div>
   );
 };

--- a/src/components/PlayerAssessmentCard.tsx
+++ b/src/components/PlayerAssessmentCard.tsx
@@ -2,7 +2,9 @@
 
 import React, { useState } from 'react';
 import { HiCheckCircle, HiXCircle } from 'react-icons/hi';
+import { useTranslation } from 'react-i18next';
 import type { Player, PlayerAssessment } from '@/types';
+import type { TranslationKey } from '@/i18n-types';
 import OverallRatingSelector from './OverallRatingSelector';
 import AssessmentSlider from './AssessmentSlider';
 import { validateAssessment } from '@/hooks/usePlayerAssessments';
@@ -27,6 +29,7 @@ const initialSliders = {
 };
 
 const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onSave, isSaved }) => {
+  const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const [overall, setOverall] = useState<number>(5);
   const [sliders, setSliders] = useState<Record<string, number>>(initialSliders);
@@ -63,11 +66,11 @@ const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onS
       {expanded && (
         <div className="mt-2 space-y-3">
           <OverallRatingSelector value={overall} onChange={setOverall} />
-          <div className="grid grid-cols-5 gap-2">
+          <div className="space-y-2">
             {Object.entries(sliders).map(([key, value]) => (
               <AssessmentSlider
                 key={key}
-                label={key}
+                label={t(`assessmentMetrics.${key}` as TranslationKey, key)}
                 value={value}
                 onChange={(v) => handleSliderChange(key, v)}
               />
@@ -89,7 +92,7 @@ const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onS
             onClick={handleSave}
             disabled={!isValid}
           >
-            Save
+            {t('playerAssessmentModal.saveButton', 'Save')}
           </button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- redesign sliders with horizontal layout
- translate metric labels and save button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687188ec2aa8832ca2e2ffeaa6d2262a