### PR TITLE
Add assessment averages tests

### DIFF
--- a/.docs/player-assessment-feature-plan.md
+++ b/.docs/player-assessment-feature-plan.md
@@ -57,9 +57,11 @@
 4. **Persistence** – wire up `updateDoc` and local state with validation. ✅
 5. **Statistics integration** – display averages in PlayerStatsView and GameStatsModal. ✅
 6. **Polish & translations** – finalize tooltips, accessibility labels and translation keys. ✅
-7. **Testing & docs** – add unit/integration tests and update documentation.
+7. **Testing & docs** – add unit/integration tests and update documentation. ✅
 
 ### Manual Testing Suggestions
 - Open a finished game and select **Assess Players** from the menu. Verify the modal appears and each card expands/collapses with a tooltip.
 - Enter slider values and notes for a player, press **Save** and confirm the header progress updates.
 - Close and reopen the modal to ensure saved players show a check mark and notes persist.
+- Open Player Stats and verify averages appear after saving assessments.
+- Check Game Stats modal shows team rating averages.

--- a/src/utils/assessmentStats.test.ts
+++ b/src/utils/assessmentStats.test.ts
@@ -1,0 +1,92 @@
+import { calculatePlayerAssessmentAverages, calculateTeamAssessmentAverages } from './assessmentStats';
+import type { SavedGamesCollection, AppState, PlayerAssessment } from '@/types';
+
+const baseGame: AppState = {
+  playersOnField: [],
+  opponents: [],
+  drawings: [],
+  availablePlayers: [],
+  showPlayerNames: true,
+  teamName: 'Team',
+  gameEvents: [],
+  opponentName: 'Opp',
+  gameDate: '2025-01-01',
+  homeScore: 0,
+  awayScore: 0,
+  gameNotes: '',
+  homeOrAway: 'home',
+  numberOfPeriods: 2,
+  periodDurationMinutes: 10,
+  currentPeriod: 1,
+  gameStatus: 'notStarted',
+  selectedPlayerIds: [],
+  assessments: {},
+  seasonId: '',
+  tournamentId: '',
+  gameLocation: '',
+  gameTime: '',
+  subIntervalMinutes: 5,
+  completedIntervalDurations: [],
+  lastSubConfirmationTimeSeconds: 0,
+  tacticalDiscs: [],
+  tacticalDrawings: [],
+  tacticalBallPosition: { relX: 0, relY: 0 },
+};
+
+const sampleAssessment = (val: number): PlayerAssessment => ({
+  overall: val,
+  sliders: {
+    intensity: val,
+    courage: val,
+    duels: val,
+    technique: val,
+    creativity: val,
+    decisions: val,
+    awareness: val,
+    teamwork: val,
+    fair_play: val,
+    impact: val,
+  },
+  notes: '',
+  minutesPlayed: 90,
+  createdAt: 0,
+  createdBy: 'me',
+});
+
+describe('assessmentStats', () => {
+  it('returns null when no assessments exist for player', () => {
+    const games: SavedGamesCollection = { g1: { ...baseGame } };
+    expect(calculatePlayerAssessmentAverages('p1', games)).toBeNull();
+  });
+
+  it('calculates player averages across games', () => {
+    const games: SavedGamesCollection = {
+      g1: { ...baseGame, assessments: { p1: sampleAssessment(4) } },
+      g2: { ...baseGame, assessments: { p1: sampleAssessment(2) } },
+    };
+    const result = calculatePlayerAssessmentAverages('p1', games);
+    expect(result?.count).toBe(2);
+    expect(result?.averages.intensity).toBe(3);
+    expect(result?.averages.impact).toBe(3);
+  });
+
+  it('computes team averages across games', () => {
+    const games: SavedGamesCollection = {
+      g1: {
+        ...baseGame,
+        assessments: { p1: sampleAssessment(4), p2: sampleAssessment(2) },
+      },
+      g2: {
+        ...baseGame,
+        assessments: { p1: sampleAssessment(3) },
+      },
+    };
+    const result = calculateTeamAssessmentAverages(games);
+    // For g1: average per metric = (4 + 2)/2 = 3
+    // For g2: average = 3
+    // Overall average across games = (3 + 3)/2 = 3
+    expect(result?.count).toBe(2);
+    expect(result?.averages.intensity).toBe(3);
+    expect(result?.averages.fair_play).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- test assessmentStats utility functions
- mark testing step as done and expand manual testing notes

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68719423bfa8832c90f3545212cd359c