### PR TITLE
Use assessment hook in modal

### DIFF
--- a/src/components/PlayerAssessmentModal.test.tsx
+++ b/src/components/PlayerAssessmentModal.test.tsx
@@ -22,6 +22,7 @@ const renderModal = (props = {}) =>
       onClose={() => {}}
       selectedPlayerIds={['p1']}
       availablePlayers={players}
+      assessments={{}}
       onSave={jest.fn()}
       {...props}
     />
@@ -39,5 +40,21 @@ describe('PlayerAssessmentModal', () => {
     fireEvent.click(screen.getByText('Player One #10'));
     fireEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(onSave).toHaveBeenCalled();
+  });
+
+  it('shows checkmark for saved players', () => {
+    const { container } = renderModal({
+      assessments: {
+        p1: {
+          overall: 5,
+          sliders: { intensity: 3, courage: 3, duels: 3, technique: 3, creativity: 3, decisions: 3, awareness: 3, teamwork: 3, fair_play: 3, impact: 3 },
+          notes: '',
+          minutesPlayed: 0,
+          createdAt: 0,
+          createdBy: 'test',
+        },
+      },
+    });
+    expect(container.querySelector('.text-indigo-400')).toBeInTheDocument();
   });
 });

--- a/src/components/PlayerAssessmentModal.tsx
+++ b/src/components/PlayerAssessmentModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Player, PlayerAssessment } from '@/types';
 import PlayerAssessmentCard from './PlayerAssessmentCard';
@@ -10,6 +10,7 @@ interface PlayerAssessmentModalProps {
   onClose: () => void;
   selectedPlayerIds: string[];
   availablePlayers: Player[];
+  assessments: { [id: string]: PlayerAssessment };
   onSave: (playerId: string, assessment: Partial<PlayerAssessment>) => void;
 }
 
@@ -18,10 +19,17 @@ const PlayerAssessmentModal: React.FC<PlayerAssessmentModalProps> = ({
   onClose,
   selectedPlayerIds,
   availablePlayers,
+  assessments,
   onSave,
 }) => {
   const { t } = useTranslation();
   const [savedIds, setSavedIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setSavedIds(Object.keys(assessments || {}));
+    }
+  }, [isOpen, assessments]);
 
   if (!isOpen) return null;
 


### PR DESCRIPTION
## Summary
- use `usePlayerAssessments` hook in `HomePage`
- pass saved assessments to `PlayerAssessmentModal`
- initialize saved state from existing assessments
- add test coverage for saved status display

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6871f133be98832ca0520ce881fb5db7