### PR TITLE
Enhance player assessments

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -546,6 +546,7 @@
     "saveButton": "Save",
     "noPlayers": "No players selected",
     "notesPlaceholder": "Add notes...",
+    "overallLabel": "Overall",
     "expand": "Expand assessment for {{name}}",
     "collapse": "Collapse assessment for {{name}}"
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -538,6 +538,7 @@
     "saveButton": "Tallenna",
     "noPlayers": "Ei valittuja pelaajia",
     "notesPlaceholder": "Kirjoita muistiinpanoja...",
+    "overallLabel": "Kokonaisarvio",
     "expand": "Avaa arviointi pelaajalle {{name}}",
     "collapse": "Sulje arviointi pelaajalle {{name}}"
   },

--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -15,7 +15,7 @@ const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onCha
       <input
         type="range"
         min={1}
-        max={5}
+        max={10}
         step={1}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}

--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -17,6 +17,7 @@ import { getTournaments as utilGetTournaments } from '@/utils/tournaments';
 import { FaSort, FaSortUp, FaSortDown, FaEdit, FaSave, FaTimes, FaTrashAlt } from 'react-icons/fa';
 import PlayerStatsView from './PlayerStatsView';
 import { calculateTeamAssessmentAverages } from '@/utils/assessmentStats';
+import RatingBar from './RatingBar';
 
 // Define the type for sortable columns
 type SortableColumn = 'name' | 'goals' | 'assists' | 'totalScore' | 'fpAwards' | 'gamesPlayed' | 'avgPoints';
@@ -1035,13 +1036,17 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                       {teamAssessmentAverages && (
                         <div className="mt-4">
                           <h4 className="text-md font-semibold mb-2">{t('playerStats.performanceRatings', 'Performance Ratings')}</h4>
-                          <div className="space-y-1 text-sm">
+                          <div className="space-y-2 text-sm">
                             {Object.entries(teamAssessmentAverages.averages).map(([metric, avg]) => (
-                              <div key={metric} className="flex justify-between px-2">
-                                <span>{t(`assessmentMetrics.${metric}` as TranslationKey, metric)}</span>
-                                <span className="text-yellow-400 font-semibold">{avg.toFixed(1)}</span>
+                              <div key={metric} className="flex items-center space-x-2 px-2">
+                                <span className="w-28 shrink-0">{t(`assessmentMetrics.${metric}` as TranslationKey, metric)}</span>
+                                <RatingBar value={avg} />
                               </div>
                             ))}
+                            <div className="flex items-center space-x-2 px-2 mt-2">
+                              <span className="w-28 shrink-0">{t('playerAssessmentModal.overallLabel', 'Overall')}</span>
+                              <RatingBar value={teamAssessmentAverages.overall} />
+                            </div>
                             <div className="text-xs text-slate-400 text-right">
                               {teamAssessmentAverages.count} {t('playerStats.ratedGames', 'rated')}
                             </div>

--- a/src/components/PlayerAssessmentCard.tsx
+++ b/src/components/PlayerAssessmentCard.tsx
@@ -17,16 +17,16 @@ interface PlayerAssessmentCardProps {
 }
 
 const initialSliders = {
-  intensity: 3,
-  courage: 3,
-  duels: 3,
-  technique: 3,
-  creativity: 3,
-  decisions: 3,
-  awareness: 3,
-  teamwork: 3,
-  fair_play: 3,
-  impact: 3,
+  intensity: 5,
+  courage: 5,
+  duels: 5,
+  technique: 5,
+  creativity: 5,
+  decisions: 5,
+  awareness: 5,
+  teamwork: 5,
+  fair_play: 5,
+  impact: 5,
 };
 
 const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onSave, isSaved, assessment }) => {
@@ -78,7 +78,12 @@ const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onS
       </button>
       {expanded && (
         <div className="mt-2 space-y-3">
-          <OverallRatingSelector value={overall} onChange={setOverall} />
+          <div className="flex items-center space-x-2">
+            <label className="text-sm text-slate-300 w-24 shrink-0">
+              {t('playerAssessmentModal.overallLabel', 'Overall')}
+            </label>
+            <OverallRatingSelector value={overall} onChange={setOverall} />
+          </div>
           <div className="space-y-2">
             {Object.entries(sliders).map(([key, value]) => (
               <AssessmentSlider

--- a/src/components/PlayerStatsView.tsx
+++ b/src/components/PlayerStatsView.tsx
@@ -8,6 +8,7 @@ import { calculatePlayerAssessmentAverages } from '@/utils/assessmentStats';
 import { format } from 'date-fns';
 import { fi, enUS } from 'date-fns/locale';
 import SparklineChart from './SparklineChart';
+import RatingBar from './RatingBar';
 
 interface PlayerStatsViewProps {
   player: Player | null;
@@ -107,13 +108,17 @@ const PlayerStatsView: React.FC<PlayerStatsViewProps> = ({ player, savedGames, o
             <span className="text-sm text-slate-400">{showRatings ? '-' : '+'}</span>
           </button>
           {showRatings && (
-            <div className="mt-2 space-y-1 text-sm">
+            <div className="mt-2 space-y-2 text-sm">
               {Object.entries(assessmentAverages.averages).map(([metric, avg]) => (
-                <div key={metric} className="flex justify-between px-2">
-                  <span>{t(`assessmentMetrics.${metric}` as TranslationKey, metric)}</span>
-                  <span className="text-yellow-400 font-semibold">{avg.toFixed(1)}</span>
+                <div key={metric} className="flex items-center space-x-2 px-2">
+                  <span className="w-28 shrink-0">{t(`assessmentMetrics.${metric}` as TranslationKey, metric)}</span>
+                  <RatingBar value={avg} />
                 </div>
               ))}
+              <div className="flex items-center space-x-2 px-2 mt-2">
+                <span className="w-28 shrink-0">{t('playerAssessmentModal.overallLabel', 'Overall')}</span>
+                <RatingBar value={assessmentAverages.overall} />
+              </div>
               <div className="text-xs text-slate-400 text-right">
                 {assessmentAverages.count} {t('playerStats.ratedGames', 'rated')}
               </div>

--- a/src/components/RatingBar.tsx
+++ b/src/components/RatingBar.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import React from 'react';
+
+interface RatingBarProps {
+  value: number;
+  max?: number;
+}
+
+const RatingBar: React.FC<RatingBarProps> = ({ value, max = 10 }) => {
+  const pct = Math.min(Math.max(value, 0), max) / max * 100;
+  return (
+    <div className="flex items-center space-x-2 w-full">
+      <div className="flex-1 h-2 bg-slate-700 rounded relative overflow-hidden">
+        <div
+          className="absolute inset-0 bg-indigo-600"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-sm text-yellow-400 w-8 text-right">{value.toFixed(1)}</span>
+    </div>
+  );
+};
+
+export default RatingBar;

--- a/src/hooks/__tests__/usePlayerAssessments.test.ts
+++ b/src/hooks/__tests__/usePlayerAssessments.test.ts
@@ -47,5 +47,6 @@ describe('validateAssessment', () => {
     expect(validateAssessment(assessment)).toBe(true);
     expect(validateAssessment({ ...assessment, overall: 11 })).toBe(false);
     expect(validateAssessment({ ...assessment, sliders: { ...assessment.sliders, intensity: 0 } })).toBe(false);
+    expect(validateAssessment({ ...assessment, sliders: { ...assessment.sliders, intensity: 11 } })).toBe(false);
   });
 });

--- a/src/hooks/usePlayerAssessments.ts
+++ b/src/hooks/usePlayerAssessments.ts
@@ -6,7 +6,7 @@ import logger from '@/utils/logger';
 export const validateAssessment = (a: Partial<PlayerAssessment>): boolean => {
   if (typeof a.overall !== 'number' || a.overall < 1 || a.overall > 10) return false;
   if (!a.sliders) return false;
-  const inRange = Object.values(a.sliders).every(v => v >= 1 && v <= 5);
+  const inRange = Object.values(a.sliders).every(v => v >= 1 && v <= 10);
   if (!inRange) return false;
   if (a.notes && a.notes.length > 280) return false;
   return true;

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -392,6 +392,7 @@ export type TranslationKey =
   | 'playerAssessmentModal.expand'
   | 'playerAssessmentModal.noPlayers'
   | 'playerAssessmentModal.notesPlaceholder'
+  | 'playerAssessmentModal.overallLabel'
   | 'playerAssessmentModal.saveButton'
   | 'playerAssessmentModal.title'
   | 'playerStats.assists'

--- a/src/utils/assessmentStats.test.ts
+++ b/src/utils/assessmentStats.test.ts
@@ -68,6 +68,7 @@ describe('assessmentStats', () => {
     expect(result?.count).toBe(2);
     expect(result?.averages.intensity).toBe(3);
     expect(result?.averages.impact).toBe(3);
+    expect(result?.overall).toBe(3);
   });
 
   it('computes team averages across games', () => {
@@ -88,5 +89,6 @@ describe('assessmentStats', () => {
     expect(result?.count).toBe(2);
     expect(result?.averages.intensity).toBe(3);
     expect(result?.averages.fair_play).toBe(3);
+    expect(result?.overall).toBe(3);
   });
 });

--- a/src/utils/assessmentStats.ts
+++ b/src/utils/assessmentStats.ts
@@ -1,6 +1,7 @@
 export interface MetricAverages {
   count: number;
   averages: { [metric: string]: number };
+  overall: number;
 }
 
 import type { SavedGamesCollection } from '@/types';
@@ -22,22 +23,25 @@ export function calculatePlayerAssessmentAverages(playerId: string, games: Saved
   let count = 0;
   const totals: Record<string, number> = {};
   METRICS.forEach(m => totals[m] = 0);
+  let overallTotal = 0;
   for (const game of Object.values(games)) {
     const a = game.assessments?.[playerId];
     if (!a) continue;
     count++;
     METRICS.forEach(m => { totals[m] += a.sliders[m]; });
+    overallTotal += a.overall;
   }
   if (count === 0) return null;
   const averages: Record<string, number> = {};
   METRICS.forEach(m => { averages[m] = totals[m] / count; });
-  return { count, averages };
+  return { count, averages, overall: overallTotal / count };
 }
 
 export function calculateTeamAssessmentAverages(games: SavedGamesCollection): MetricAverages | null {
   let count = 0;
   const totals: Record<string, number> = {};
   METRICS.forEach(m => totals[m] = 0);
+  let overallTotal = 0;
   for (const game of Object.values(games)) {
     if (!game.assessments) continue;
     const players = Object.values(game.assessments);
@@ -48,6 +52,7 @@ export function calculateTeamAssessmentAverages(games: SavedGamesCollection): Me
     players.forEach(a => {
       METRICS.forEach(m => { perMetricTotals[m] += a.sliders[m]; });
     });
+    overallTotal += players.reduce((s, a) => s + a.overall, 0) / players.length;
     METRICS.forEach(m => {
       totals[m] += perMetricTotals[m] / players.length;
     });
@@ -55,5 +60,5 @@ export function calculateTeamAssessmentAverages(games: SavedGamesCollection): Me
   if (count === 0) return null;
   const averages: Record<string, number> = {};
   METRICS.forEach(m => { averages[m] = totals[m] / count; });
-  return { count, averages };
+  return { count, averages, overall: overallTotal / count };
 }


### PR DESCRIPTION
## Summary
- expand slider scale to 1–10
- label overall rating selector
- show averages with new `RatingBar`
- compute overall rating average
- update translations

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687213433bc8832cbb10fcc2cc604644