### PR TITLE
Add wheel picker for assessment slider

### DIFF
--- a/src/components/AssessmentSlider.test.tsx
+++ b/src/components/AssessmentSlider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AssessmentSlider from './AssessmentSlider';
 
@@ -7,7 +7,24 @@ describe('AssessmentSlider', () => {
   it('calls onChange with the slider value', () => {
     const onChange = jest.fn();
     render(<AssessmentSlider label="test" value={3} onChange={onChange} />);
-    fireEvent.change(screen.getByRole('slider'), { target: { value: '4' } });
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('step', '0.5');
+    fireEvent.change(slider, { target: { value: '4' } });
     expect(onChange).toHaveBeenCalledWith(4);
+  });
+
+  it('shows wheel picker on long press', () => {
+    jest.useFakeTimers();
+    const onChange = jest.fn();
+    render(<AssessmentSlider label="test" value={3} onChange={onChange} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.pointerDown(slider);
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    const picker = screen.getByTestId('wheel-picker');
+    expect(picker).toBeInTheDocument();
+    fireEvent.change(picker, { target: { value: '5.5' } });
+    expect(onChange).toHaveBeenCalledWith(5.5);
   });
 });

--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -10,7 +10,7 @@ interface AssessmentSliderProps {
 
 const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onChange }) => {
   const [showPicker, setShowPicker] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout>();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const numbers = Array.from({ length: 19 }, (_, i) => 1 + i * 0.5);
 

--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useRef, useState } from 'react';
 
 interface AssessmentSliderProps {
   label: string;
@@ -9,19 +9,60 @@ interface AssessmentSliderProps {
 }
 
 const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onChange }) => {
+  const [showPicker, setShowPicker] = useState(false);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  const numbers = Array.from({ length: 19 }, (_, i) => 1 + i * 0.5);
+
+  const handlePointerDown = () => {
+    timeoutRef.current = setTimeout(() => setShowPicker(true), 500);
+  };
+
+  const clearTimer = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+  };
+
+  const handlePointerUp = () => {
+    clearTimer();
+  };
+
   return (
-    <div className="flex items-center space-x-2 w-full">
+    <div className="flex items-center space-x-2 w-full relative">
       <label className="text-sm text-slate-300 w-24 shrink-0">{label}</label>
       <input
         type="range"
         min={1}
         max={10}
-        step={1}
+        step={0.5}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerUp}
         className="flex-1 h-2 rounded-lg appearance-none cursor-pointer bg-slate-600 accent-indigo-600"
       />
       <span className="text-sm text-yellow-400 w-6 text-right">{value}</span>
+      {showPicker && (
+        <select
+          data-testid="wheel-picker"
+          value={value}
+          onChange={(e) => {
+            onChange(Number(e.target.value));
+            setShowPicker(false);
+          }}
+          onBlur={() => setShowPicker(false)}
+          size={5}
+          className="absolute top-full mt-1 bg-slate-700 text-white rounded-md p-1 focus:outline-none"
+        >
+          {numbers.map((n) => (
+            <option key={n} value={n} className="text-center">
+              {n}
+            </option>
+          ))}
+        </select>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- support 0.5 increments on the assessment slider
- show wheel picker on long press
- test the new step value and picker functionality

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68721cafc76c832c9f99bdc4a145143b