### PR TITLE
Remove wheel picker from assessment slider

### DIFF
--- a/.docs/player-assessment-feature-plan.md
+++ b/.docs/player-assessment-feature-plan.md
@@ -22,7 +22,7 @@
 ## 3. Modal UI Components
 1. Create reusable components:
    - `OverallRatingSelector` – segmented buttons 1‒10.
-   - `AssessmentSlider` – vertical slider with ±0.5 step and long‑press wheel picker.
+   - `AssessmentSlider` – vertical slider with ±0.5 step.
    - Multiline notes `TextInput` with character count.
 2. Build `PlayerAssessmentCard` showing player avatar, name, jersey number, goal/assist counts and status icon.
 3. Follow modal styling rules in `.docs/STYLE_GUIDE.md` for container, header, body and footer classes.

--- a/src/components/AssessmentSlider.test.tsx
+++ b/src/components/AssessmentSlider.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import AssessmentSlider from './AssessmentSlider';
 
@@ -13,18 +13,4 @@ describe('AssessmentSlider', () => {
     expect(onChange).toHaveBeenCalledWith(4);
   });
 
-  it('shows wheel picker on long press', () => {
-    jest.useFakeTimers();
-    const onChange = jest.fn();
-    render(<AssessmentSlider label="test" value={3} onChange={onChange} />);
-    const slider = screen.getByRole('slider');
-    fireEvent.pointerDown(slider);
-    act(() => {
-      jest.advanceTimersByTime(600);
-    });
-    const picker = screen.getByTestId('wheel-picker');
-    expect(picker).toBeInTheDocument();
-    fireEvent.change(picker, { target: { value: '5.5' } });
-    expect(onChange).toHaveBeenCalledWith(5.5);
-  });
 });

--- a/src/components/AssessmentSlider.tsx
+++ b/src/components/AssessmentSlider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React from 'react';
 
 interface AssessmentSliderProps {
   label: string;
@@ -9,27 +9,8 @@ interface AssessmentSliderProps {
 }
 
 const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onChange }) => {
-  const [showPicker, setShowPicker] = useState(false);
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  const numbers = Array.from({ length: 19 }, (_, i) => 1 + i * 0.5);
-
-  const startTimer = () => {
-    timeoutRef.current = setTimeout(() => setShowPicker(true), 500);
-  };
-
-  const clearTimer = () => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-  };
-
-  const endTimer = () => {
-    clearTimer();
-  };
-
   return (
-    <div className="flex items-center space-x-2 w-full relative">
+    <div className="flex items-center space-x-2 w-full">
       <label className="text-sm text-slate-300 w-24 shrink-0">{label}</label>
       <input
         type="range"
@@ -38,37 +19,9 @@ const AssessmentSlider: React.FC<AssessmentSliderProps> = ({ label, value, onCha
         step={0.5}
         value={value}
         onChange={(e) => onChange(Number(e.target.value))}
-        onPointerDown={startTimer}
-        onPointerUp={endTimer}
-        onPointerLeave={endTimer}
-        onMouseDown={startTimer}
-        onMouseUp={endTimer}
-        onMouseLeave={endTimer}
-        onTouchStart={startTimer}
-        onTouchEnd={endTimer}
-        onTouchCancel={endTimer}
         className="flex-1 h-2 rounded-lg appearance-none cursor-pointer bg-slate-600 accent-indigo-600"
       />
       <span className="text-sm text-yellow-400 w-6 text-right">{value}</span>
-      {showPicker && (
-        <select
-          data-testid="wheel-picker"
-          value={value}
-          onChange={(e) => {
-            onChange(Number(e.target.value));
-            setShowPicker(false);
-          }}
-          onBlur={() => setShowPicker(false)}
-          size={5}
-          className="absolute top-full mt-1 bg-slate-700 text-white rounded-md p-1 focus:outline-none"
-        >
-          {numbers.map((n) => (
-            <option key={n} value={n} className="text-center">
-              {n}
-            </option>
-          ))}
-        </select>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- simplify `AssessmentSlider` component by removing wheel picker
- update unit tests
- update feature plan docs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687243727584832c88e1c3545a90bfeb