### PR TITLE
Fix graph highlight style

### DIFF
--- a/src/components/MetricTrendChart.tsx
+++ b/src/components/MetricTrendChart.tsx
@@ -21,7 +21,7 @@ const MetricTrendChart: React.FC<MetricTrendChartProps> = ({ data }) => {
           <CartesianGrid stroke="#4b5563" strokeDasharray="3 3" vertical={false} />
           <YAxis hide domain={[0, max]} />
           <Tooltip cursor={{ stroke: '#334155' }} labelFormatter={(v) => new Date(v as string).toLocaleDateString()} />
-          <Line type="monotone" dataKey="value" stroke="#facc15" dot={false} strokeWidth={2} />
+          <Line type="monotone" dataKey="value" stroke="#facc15" dot={false} activeDot={false} strokeWidth={2} />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/src/components/SparklineChart.tsx
+++ b/src/components/SparklineChart.tsx
@@ -65,8 +65,8 @@ const SparklineChart: React.FC<SparklineChartProps> = ({ data, goalsLabel, assis
             wrapperStyle={{ fontSize: '12px', paddingTop: '10px' }} 
           />
           <ReferenceLine y={averagePoints} stroke="#94a3b8" strokeDasharray="4 4" />
-          <Area type="monotone" dataKey="goals" fill="#22c55e" stroke="#22c55e" name={goalsLabel} fillOpacity={0.2} dot={<CustomizedDot />} />
-          <Area type="monotone" dataKey="assists" fill="#3b82f6" stroke="#3b82f6" name={assistsLabel} fillOpacity={0.2} dot={<CustomizedDot />} />
+          <Area type="monotone" dataKey="goals" fill="#22c55e" stroke="#22c55e" name={goalsLabel} fillOpacity={0.2} dot={<CustomizedDot />} activeDot={false} />
+          <Area type="monotone" dataKey="assists" fill="#3b82f6" stroke="#3b82f6" name={assistsLabel} fillOpacity={0.2} dot={<CustomizedDot />} activeDot={false} />
         </ComposedChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- hide the active dot on trend chart lines
- hide the active dot on sparkline areas

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872528eeed4832c80f401bf407aeaf8