### PR TITLE
Fix rating selector overflow

### DIFF
--- a/src/components/OverallRatingSelector.tsx
+++ b/src/components/OverallRatingSelector.tsx
@@ -10,7 +10,7 @@ interface OverallRatingSelectorProps {
 const OverallRatingSelector: React.FC<OverallRatingSelectorProps> = ({ value, onChange }) => {
   const numbers = Array.from({ length: 10 }, (_, i) => i + 1);
   return (
-    <div className="flex space-x-1">
+    <div className="flex flex-wrap gap-1">
       {numbers.map((n) => (
         <button
           key={n}


### PR DESCRIPTION
## Summary
- allow OverallRatingSelector buttons to wrap to the next line

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687252f6f820832cadb24d30ef5e0474