### PR TITLE
Fix tooltip background on progress graphs

### DIFF
--- a/src/components/MetricTrendChart.tsx
+++ b/src/components/MetricTrendChart.tsx
@@ -20,7 +20,11 @@ const MetricTrendChart: React.FC<MetricTrendChartProps> = ({ data }) => {
         <LineChart data={chartData} margin={{ top: 5, right: 5, left: 0, bottom: 0 }}>
           <CartesianGrid stroke="#4b5563" strokeDasharray="3 3" vertical={false} />
           <YAxis hide domain={[0, max]} />
-          <Tooltip cursor={{ stroke: '#334155' }} labelFormatter={(v) => new Date(v as string).toLocaleDateString()} />
+          <Tooltip
+            cursor={{ stroke: '#334155' }}
+            labelFormatter={(v) => new Date(v as string).toLocaleDateString()}
+            wrapperStyle={{ backgroundColor: 'transparent', border: 'none', boxShadow: 'none' }}
+          />
           <Line type="monotone" dataKey="value" stroke="#facc15" dot={false} activeDot={false} strokeWidth={2} />
         </LineChart>
       </ResponsiveContainer>

--- a/src/components/SparklineChart.tsx
+++ b/src/components/SparklineChart.tsx
@@ -58,7 +58,10 @@ const SparklineChart: React.FC<SparklineChartProps> = ({ data, goalsLabel, assis
             domain={[0, maxPoints]}
             allowDecimals={false}
           />
-          <Tooltip content={<CustomTooltip goalsLabel={goalsLabel} assistsLabel={assistsLabel} />} />
+          <Tooltip
+            content={<CustomTooltip goalsLabel={goalsLabel} assistsLabel={assistsLabel} />}
+            wrapperStyle={{ backgroundColor: 'transparent', border: 'none', boxShadow: 'none' }}
+          />
           <Legend 
             iconType="circle"
             iconSize={8}


### PR DESCRIPTION
## Summary
- make Recharts tooltip wrappers transparent in PlayerStats charts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727e21b390832cac0972141221f9e3