### PR TITLE
Remove jersey numbers from player assessment display

### DIFF
--- a/src/components/PlayerAssessmentCard.test.tsx
+++ b/src/components/PlayerAssessmentCard.test.tsx
@@ -9,13 +9,13 @@ describe('PlayerAssessmentCard', () => {
 
   it('renders player name', () => {
     render(<PlayerAssessmentCard player={player} onSave={jest.fn()} />);
-    expect(screen.getByText('Test #9')).toBeInTheDocument();
+    expect(screen.getByText('Test')).toBeInTheDocument();
   });
 
   it('calls onSave with assessment', () => {
     const onSave = jest.fn();
     render(<PlayerAssessmentCard player={player} onSave={onSave} />);
-    fireEvent.click(screen.getByText('Test #9'));
+    fireEvent.click(screen.getByText('Test'));
     fireEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(onSave).toHaveBeenCalled();
   });
@@ -35,7 +35,7 @@ describe('PlayerAssessmentCard', () => {
         }}
       />
     );
-    fireEvent.click(screen.getByText('Test #9'));
+    fireEvent.click(screen.getByText('Test'));
     expect(screen.getByDisplayValue('note')).toBeInTheDocument();
   });
 });

--- a/src/components/PlayerAssessmentCard.tsx
+++ b/src/components/PlayerAssessmentCard.tsx
@@ -80,10 +80,7 @@ const PlayerAssessmentCard: React.FC<PlayerAssessmentCardProps> = ({ player, onS
         aria-expanded={expanded}
         title={expanded ? t('playerAssessmentModal.collapse', { name: player.name }) : t('playerAssessmentModal.expand', { name: player.name })}
       >
-        <span className="font-semibold">
-          {player.name}
-          {player.jerseyNumber ? ` #${player.jerseyNumber}` : ''}
-        </span>
+        <span className="font-semibold">{player.name}</span>
         {isSaved ? (
           <HiCheckCircle className="text-indigo-400" />
         ) : (

--- a/src/components/PlayerAssessmentModal.test.tsx
+++ b/src/components/PlayerAssessmentModal.test.tsx
@@ -31,13 +31,13 @@ const renderModal = (props = {}) =>
 describe('PlayerAssessmentModal', () => {
   it('renders selected player', () => {
     renderModal();
-    expect(screen.getByText('Player One #10')).toBeInTheDocument();
+    expect(screen.getByText('Player One')).toBeInTheDocument();
   });
 
   it('calls onSave when save button clicked', () => {
     const onSave = jest.fn();
     renderModal({ onSave });
-    fireEvent.click(screen.getByText('Player One #10'));
+    fireEvent.click(screen.getByText('Player One'));
     fireEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(onSave).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- remove jersey numbers from PlayerAssessmentCard so the modal only shows the player's name
- update PlayerAssessmentCard tests
- update PlayerAssessmentModal tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68727db92030832cbd76121adb96dcc1