### PR TITLE
Implement demand correction weighting

### DIFF
--- a/.docs/demand-correction-toggle-plan.md
+++ b/.docs/demand-correction-toggle-plan.md
@@ -29,3 +29,6 @@ Certain matches are more demanding than others, making raw performance scores ha
 - Update manual testing docs to verify that enabling the toggle changes displayed averages.
 
 This feature will help coaches compare player performance more fairly when some opponents present tougher challenges.
+
+## Status
+- [x] Demand correction toggle implemented and documented.

--- a/.docs/security-enhancement-plan.md
+++ b/.docs/security-enhancement-plan.md
@@ -37,3 +37,6 @@ This document summarizes a security audit of the Soccer Pre-Game App and outline
    - This reduces the chance of data corruption when updating the app.
 
 Implementing these features will reduce the likelihood of accidental data loss and provide an option for more secure local storage.
+
+## Status
+- [x] Automatic periodic backups added via useAutoBackup hook.

--- a/MANUAL_TESTING.md
+++ b/MANUAL_TESTING.md
@@ -11,5 +11,6 @@ Use this short checklist to manually verify key workflows after making changes t
 7. **Try new assessment UI** – Expand a player card and verify the segmented overall selector, sliders and notes input work. Saving should collapse the card and show a checkmark.
 8. **Review assessment progress** – Save ratings for multiple players and ensure the header progress updates and saved players show a ✔ icon.
 9. **Check performance averages** – Open a player's stats page and confirm the new Performance Ratings section shows average slider values and number of rated games. In Game Stats, open the Overall tab to see team rating averages.
+10. **Toggle demand correction** – In Player Stats view, enable the *Weight by Difficulty* option and verify averages change when games use different difficulty factors.
 
 Running through these steps after updates helps catch regressions before deploying.

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -590,6 +590,8 @@
     "notes": "Assessment Notes",
     "metricTrends": "Rating Trends",
     "metricSelect": "Select Metric",
-    "goalsAssists": "Goals & Assists"
+    "goalsAssists": "Goals & Assists",
+    "useDemandCorrection": "Weight by Difficulty",
+    "useDemandCorrectionTooltip": "When enabled, ratings from harder games count more"
   }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -582,6 +582,8 @@
     "notes": "Arvioinnin muistiinpanot",
     "metricTrends": "Arvioiden trendit",
     "metricSelect": "Valitse mittari",
-    "goalsAssists": "Maalit ja syötöt"
+    "goalsAssists": "Maalit ja syötöt",
+    "useDemandCorrection": "Painota vaikeuden mukaan",
+    "useDemandCorrectionTooltip": "Kun käytössä, vaikeiden pelien arviot vaikuttavat enemmän"
   }
 }

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -417,6 +417,8 @@ export type TranslationKey =
   | 'playerStats.title'
   | 'playerStats.totalsRow'
   | 'playerStats.tournamentPerformance'
+  | 'playerStats.useDemandCorrection'
+  | 'playerStats.useDemandCorrectionTooltip'
   | 'playerStats.vs'
   | 'rosterSettingsModal.addNewPlayerTitle'
   | 'rosterSettingsModal.addPlayerButton'

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -61,6 +61,8 @@ export interface AppState {
   assessments?: { [playerId: string]: PlayerAssessment };
   seasonId: string;
   tournamentId: string;
+  /** Difficulty weighting factor for demand-correction averages */
+  demandFactor?: number;
   gameLocation?: string;
   gameTime?: string;
   subIntervalMinutes?: number;

--- a/src/utils/appSettings.test.ts
+++ b/src/utils/appSettings.test.ts
@@ -50,7 +50,8 @@ describe('App Settings Utilities', () => {
         hasSeenAppGuide: false,
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
-        lastBackupTime: undefined
+        lastBackupTime: undefined,
+        useDemandCorrection: false
       });
     });
 
@@ -68,7 +69,8 @@ describe('App Settings Utilities', () => {
         hasSeenAppGuide: false,
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
-        lastBackupTime: undefined
+        lastBackupTime: undefined,
+        useDemandCorrection: false
       });
     });
 
@@ -86,7 +88,8 @@ describe('App Settings Utilities', () => {
         hasSeenAppGuide: false,
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
-        lastBackupTime: undefined
+        lastBackupTime: undefined,
+        useDemandCorrection: false
       });
       
       consoleSpy.mockRestore();
@@ -107,7 +110,8 @@ describe('App Settings Utilities', () => {
         hasSeenAppGuide: false,
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
-        lastBackupTime: undefined
+        lastBackupTime: undefined,
+        useDemandCorrection: false
       });
       consoleSpy.mockRestore();
     });
@@ -165,7 +169,8 @@ describe('App Settings Utilities', () => {
         hasSeenAppGuide: false,
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
-        lastBackupTime: undefined
+        lastBackupTime: undefined,
+        useDemandCorrection: false
       });
       
       expect(localStorageMock.setItem).toHaveBeenCalledWith(
@@ -177,7 +182,8 @@ describe('App Settings Utilities', () => {
           hasSeenAppGuide: false,
           autoBackupEnabled: false,
           autoBackupIntervalHours: 24,
-          lastBackupTime: undefined
+          lastBackupTime: undefined,
+          useDemandCorrection: false
         })
       );
     });
@@ -254,7 +260,8 @@ describe('App Settings Utilities', () => {
           language: 'fi',
           hasSeenAppGuide: false,
           autoBackupEnabled: false,
-          autoBackupIntervalHours: 24
+          autoBackupIntervalHours: 24,
+          useDemandCorrection: false
         })
       );
       expect(result).toBe(true);
@@ -338,7 +345,8 @@ describe('App Settings Utilities', () => {
         const savedSettings = JSON.parse(appSettingsCall[1]);
         expect(savedSettings).toEqual({
           ...currentSettings, // Ensure other settings are preserved
-          lastHomeTeamName: 'New Team Name' // The updated value
+          lastHomeTeamName: 'New Team Name', // The updated value
+          useDemandCorrection: false
         });
       }
 
@@ -379,7 +387,8 @@ describe('App Settings Utilities', () => {
           hasSeenAppGuide: false,
           autoBackupEnabled: false,
           autoBackupIntervalHours: 24,
-          lastBackupTime: undefined
+          lastBackupTime: undefined,
+          useDemandCorrection: false
         })
       );
       expect(result).toBe(true);

--- a/src/utils/appSettings.ts
+++ b/src/utils/appSettings.ts
@@ -23,6 +23,7 @@ export interface AppSettings {
   autoBackupEnabled?: boolean;
   autoBackupIntervalHours?: number;
   lastBackupTime?: string;
+  useDemandCorrection?: boolean;
   // Add other settings as needed
 }
 
@@ -37,6 +38,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   autoBackupEnabled: false,
   autoBackupIntervalHours: 24,
   lastBackupTime: undefined,
+  useDemandCorrection: false,
 };
 
 /**

--- a/src/utils/assessmentStats.test.ts
+++ b/src/utils/assessmentStats.test.ts
@@ -111,4 +111,15 @@ describe('assessmentStats', () => {
     const notes = getPlayerAssessmentNotes('p1', games);
     expect(notes[0].notes).toBe('good');
   });
+
+  it('weights averages using demand factor when enabled', () => {
+    const games: SavedGamesCollection = {
+      g1: { ...baseGame, demandFactor: 1, assessments: { p1: sampleAssessment(4) } },
+      g2: { ...baseGame, demandFactor: 0.5, assessments: { p1: sampleAssessment(2) } },
+    };
+    const result = calculatePlayerAssessmentAverages('p1', games, true);
+    const divisor = 1 + 0.5;
+    const expected = (4 * 1 + 2 * 0.5) / divisor;
+    expect(result?.overall).toBeCloseTo(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- add demand correction weighting logic for player and team stats
- toggle weights in PlayerStatsView with persistent setting
- update translations and docs
- mark demand correction and auto backups done in docs

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68728cd1e79c832c86c1c9c4e7dda88a