### PR TITLE
Fix demand factor persistence

### DIFF
--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -895,7 +895,10 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       onChange={(v) => {
                         onDemandFactorChange(v);
                         if (currentGameId) {
-                          updateGameDetails(currentGameId, { demandFactor: v });
+                          updateGameDetailsMutation.mutate({
+                            gameId: currentGameId,
+                            updates: { demandFactor: v },
+                          });
                         }
                       }}
                       min={0.5}

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -429,6 +429,7 @@ function HomePage() {
 
   // <<< ADD State to hold player IDs for the next new game >>>
   const [playerIdsForNewGame, setPlayerIdsForNewGame] = useState<string[] | null>(null);
+  const [newGameDemandFactor, setNewGameDemandFactor] = useState(1);
   // <<< ADD State for the roster prompt toast >>>
   // const [showRosterPrompt, setShowRosterPrompt] = useState<boolean>(false);
 
@@ -825,6 +826,7 @@ function HomePage() {
         tournamentId: gameData.tournamentId ?? undefined,
         gameLocation: gameData.gameLocation,
         gameTime: gameData.gameTime,
+        demandFactor: gameData.demandFactor,
         gameEvents: gameData.gameEvents,
         subIntervalMinutes: gameData.subIntervalMinutes,
         completedIntervalDurations: gameData.completedIntervalDurations,
@@ -882,6 +884,7 @@ function HomePage() {
       tournamentId: gameData?.tournamentId ?? initialGameSessionData.tournamentId,
       gameLocation: gameData?.gameLocation ?? initialGameSessionData.gameLocation,
       gameTime: gameData?.gameTime ?? initialGameSessionData.gameTime,
+      demandFactor: gameData?.demandFactor ?? initialGameSessionData.demandFactor,
       subIntervalMinutes: gameData?.subIntervalMinutes ?? initialGameSessionData.subIntervalMinutes,
       completedIntervalDurations: gameData?.completedIntervalDurations ?? initialGameSessionData.completedIntervalDurations,
       lastSubConfirmationTimeSeconds: gameData?.lastSubConfirmationTimeSeconds ?? initialGameSessionData.lastSubConfirmationTimeSeconds,
@@ -945,6 +948,7 @@ function HomePage() {
           tournamentId: gameSessionState.tournamentId, // USE gameSessionState
           gameLocation: gameSessionState.gameLocation,
           gameTime: gameSessionState.gameTime,
+          demandFactor: gameSessionState.demandFactor,
           subIntervalMinutes: gameSessionState.subIntervalMinutes,
           completedIntervalDurations: gameSessionState.completedIntervalDurations,
           lastSubConfirmationTimeSeconds: gameSessionState.lastSubConfirmationTimeSeconds,
@@ -2088,6 +2092,7 @@ function HomePage() {
 
       // Close the setup modal
       setIsNewGameSetupModalOpen(false);
+      setNewGameDemandFactor(1);
 
       // <<< Trigger the roster button highlight >>>
       logger.log('[handleStartNewGameWithSetup] Setting highlightRosterButton to true.'); // Log highlight trigger
@@ -2118,6 +2123,7 @@ function HomePage() {
 
     setHasSkippedInitialSetup(true); // Still mark as skipped if needed elsewhere
     setIsNewGameSetupModalOpen(false); // ADDED: Explicitly close the modal
+    setNewGameDemandFactor(1);
 
   // REMOVED initialState from dependencies
   }, [setHasSkippedInitialSetup, setIsNewGameSetupModalOpen]); // Updated dependencies
@@ -2551,6 +2557,8 @@ function HomePage() {
         <NewGameSetupModal
           isOpen={isNewGameSetupModalOpen}
           initialPlayerSelection={playerIdsForNewGame} // <<< Pass the state here
+          demandFactor={newGameDemandFactor}
+          onDemandFactorChange={setNewGameDemandFactor}
           onStart={handleStartNewGameWithSetup} // CORRECTED Handler
           onCancel={handleCancelNewGameSetup} 
           // Pass the new mutation functions

--- a/src/components/NewGameSetupModal.test.tsx
+++ b/src/components/NewGameSetupModal.test.tsx
@@ -103,6 +103,8 @@ describe('NewGameSetupModal', () => {
     addSeasonMutation: mockAddSeasonMutation as UseMutationResult<Season | null, Error, { name: string }, unknown>,
     addTournamentMutation: mockAddTournamentMutation as UseMutationResult<Tournament | null, Error, { name: string }, unknown>,
     isAddingSeason: false, isAddingTournament: false,
+    demandFactor: 1,
+    onDemandFactorChange: jest.fn(),
   };
 
   const mockSeasonsData = [{ id: 'season1', name: 'Spring 2024' }, { id: 'season2', name: 'Summer 2024' }];

--- a/src/components/NewGameSetupModal.tsx
+++ b/src/components/NewGameSetupModal.tsx
@@ -15,6 +15,8 @@ import AssessmentSlider from './AssessmentSlider';
 interface NewGameSetupModalProps {
   isOpen: boolean;
   initialPlayerSelection: string[] | null;
+  demandFactor: number;
+  onDemandFactorChange: (factor: number) => void;
   onStart: (
     initialSelectedPlayerIds: string[],
     homeTeamName: string,
@@ -39,6 +41,8 @@ interface NewGameSetupModalProps {
 const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
   isOpen,
   initialPlayerSelection,
+  demandFactor,
+  onDemandFactorChange,
   onStart,
   onCancel,
   addSeasonMutation,
@@ -73,8 +77,6 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
   // state for periods and duration
   const [localNumPeriods, setLocalNumPeriods] = useState<1 | 2>(2);
   const [localPeriodDurationString, setLocalPeriodDurationString] = useState<string>('10');
-
-  const [demandFactor, setDemandFactor] = useState(1);
 
   // <<< Step 4a: State for Home/Away >>>
   const [localHomeOrAway, setLocalHomeOrAway] = useState<'home' | 'away'>('home');
@@ -792,7 +794,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                         <AssessmentSlider
                           label={t('newGameSetupModal.demandFactorLabel', 'Game Demand Level')}
                           value={demandFactor}
-                          onChange={setDemandFactor}
+                          onChange={onDemandFactorChange}
                           min={0.5}
                           max={1.5}
                           step={0.05}


### PR DESCRIPTION
## Summary
- save `demandFactor` in game snapshot and load it when restoring a game
- update history state with the demand value
- use React Query mutation when updating demand level in the Game Settings modal
- control demand factor in NewGameSetupModal via props
- adjust tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872b447eb00832cbbf5604a88c443b3