### PR TITLE
Compute finalScore for assessment averages

### DIFF
--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -1047,6 +1047,10 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                               <span className="w-28 shrink-0">{t('playerAssessmentModal.overallLabel', 'Overall')}</span>
                               <RatingBar value={teamAssessmentAverages.overall} />
                             </div>
+                            <div className="flex items-center space-x-2 px-2">
+                              <span className="w-28 shrink-0">{t('playerStats.avgRating', 'Avg Rating')}</span>
+                              <RatingBar value={teamAssessmentAverages.finalScore} />
+                            </div>
                             <div className="text-xs text-slate-400 text-right">
                               {teamAssessmentAverages.count} {t('playerStats.ratedGames', 'rated')}
                             </div>

--- a/src/components/PlayerStatsView.tsx
+++ b/src/components/PlayerStatsView.tsx
@@ -189,6 +189,10 @@ const PlayerStatsView: React.FC<PlayerStatsViewProps> = ({ player, savedGames, o
                   <span className="w-28 shrink-0">{t('playerAssessmentModal.overallLabel', 'Overall')}</span>
                   <RatingBar value={assessmentAverages.overall} />
                 </div>
+                <div className="flex items-center space-x-2 px-2">
+                  <span className="w-28 shrink-0">{t('playerStats.avgRating', 'Avg Rating')}</span>
+                  <RatingBar value={assessmentAverages.finalScore} />
+                </div>
                 <div className="text-xs text-slate-400 text-right">
                   {assessmentAverages.count} {t('playerStats.ratedGames', 'rated')}
                 </div>

--- a/src/utils/assessmentStats.test.ts
+++ b/src/utils/assessmentStats.test.ts
@@ -122,4 +122,37 @@ describe('assessmentStats', () => {
     const expected = (4 * 1 + 2 * 0.5) / divisor;
     expect(result?.overall).toBeCloseTo(expected);
   });
+
+  it('calculates finalScore for a single game', () => {
+    const assessment: PlayerAssessment = {
+      ...sampleAssessment(0),
+      overall: 5,
+      sliders: {
+        intensity: 4,
+        courage: 6,
+        duels: 2,
+        technique: 3,
+        creativity: 5,
+        decisions: 4,
+        awareness: 5,
+        teamwork: 6,
+        fair_play: 5,
+        impact: 4,
+      },
+    };
+    const games: SavedGamesCollection = { g1: { ...baseGame, assessments: { p1: assessment } } };
+    const result = calculatePlayerAssessmentAverages('p1', games);
+    expect(result?.finalScore).toBeCloseTo(4.4);
+  });
+
+  it('weights finalScore using demand factor', () => {
+    const games: SavedGamesCollection = {
+      g1: { ...baseGame, demandFactor: 2, assessments: { p1: sampleAssessment(4) } },
+      g2: { ...baseGame, demandFactor: 1, assessments: { p1: sampleAssessment(6) } },
+    };
+    const result = calculatePlayerAssessmentAverages('p1', games, true);
+    const divisor = 2 + 1;
+    const expected = (4 * 2 + 6 * 1) / divisor;
+    expect(result?.finalScore).toBeCloseTo(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- derive new `finalScore` from assessment metrics
- weight `finalScore` in player and team averages
- show computed average rating in `PlayerStatsView` and `GameStatsModal`
- cover `finalScore` in unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872c733ae4c832ca4cfa8aeed3771ca