### PR TITLE
Implement part of season/tournament plan

### DIFF
--- a/.docs/TODO.md
+++ b/.docs/TODO.md
@@ -103,7 +103,8 @@
   - Add color or badge customization options
   - Show quick statistics like total games played and goals scored
   - Implement import and export of season or tournament setups
-  - Offer calendar (.ics) file generation when dates are defined
+- Offer calendar (.ics) file generation when dates are defined
+  - See `season-tournament-management-plan.md` for planning details
 
 ## 🎨 UI/UX Improvements
 
@@ -197,7 +198,7 @@
   - Add optional user authentication and cloud sync using Supabase.
   - Keep localStorage as the local cache and synchronize on sign in.
 
-- **Player Performance Evaluations**
+- [x] **Player Performance Evaluations**
   - Add a modal with ten sliders to rate each player after a game.
   - Store ratings per player and game to build aggregated stats.
   - Use collected data to generate a player profile/analysis view.

--- a/.docs/season-tournament-management-plan.md
+++ b/.docs/season-tournament-management-plan.md
@@ -1,0 +1,32 @@
+# Season & Tournament Management Enhancement Plan
+
+This plan expands the organizational features around seasons and tournaments referenced in the project TODO list【F:.docs/TODO.md†L95-L108】.
+
+## 1. Extended Data Model
+- Add optional fields to `Season` and `Tournament` objects for default game parameters: `location`, `periodCount`, and `periodDuration`.
+- Include `startDate` and `endDate` or an array of explicit game dates for tournaments.
+- Support `archived` flag to hide old seasons/tournaments from active menus.
+- Allow attaching a default roster ID and rich text `notes`.
+- Store optional `color` or `badge` style settings.
+
+## 2. Prefill & Roster Logic
+- When creating a new game, auto-populate settings from the selected season or tournament.
+- If a default roster is assigned, preselect those players.
+- Persist these defaults using existing localStorage helpers.
+
+## 3. UI Updates
+- Expand `SeasonTournamentManagementModal` with inputs for the new fields.
+- Add archive toggle and quick stats section showing total games and goals.
+- Provide buttons to export/import season or tournament setups as JSON.
+- Offer a button to generate a calendar (.ics) file when dates are defined.
+
+## 4. Tasks
+1. **Data schema changes** – update types and local storage helpers.
+2. **Modal form additions** – implement new inputs and archive toggle.
+3. **Game creation prefill** – auto-populate new game settings and roster.
+4. **Import/export utilities** – allow JSON backup of season/tournament data.
+5. **Calendar export** – create `.ics` generation helper.
+
+## Status
+- [x] Data schema changes implemented
+- [ ] Remaining tasks pending

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,13 +21,35 @@ export interface PlayerStatRow extends Player {
 }
 
 export interface Season {
-  id: string; 
-  name: string; 
+  id: string;
+  name: string;
+  location?: string;
+  periodCount?: number;
+  periodDuration?: number;
+  startDate?: string;
+  endDate?: string;
+  gameDates?: string[];
+  archived?: boolean;
+  defaultRosterId?: string;
+  notes?: string;
+  color?: string;
+  badge?: string;
 }
 
 export interface Tournament {
   id: string;
   name: string;
+  location?: string;
+  periodCount?: number;
+  periodDuration?: number;
+  startDate?: string;
+  endDate?: string;
+  gameDates?: string[];
+  archived?: boolean;
+  defaultRosterId?: string;
+  notes?: string;
+  color?: string;
+  badge?: string;
 }
 
 export * from './playerAssessment';

--- a/src/utils/seasons.ts
+++ b/src/utils/seasons.ts
@@ -44,9 +44,10 @@ export const saveSeasons = async (seasons: Season[]): Promise<boolean> => {
 /**
  * Adds a new season to the list of seasons in localStorage.
  * @param newSeasonName - The name of the new season.
+ * @param extra - Optional additional fields for the season.
  * @returns A promise that resolves to the newly created Season object, or null if validation/save fails.
  */
-export const addSeason = async (newSeasonName: string): Promise<Season | null> => {
+export const addSeason = async (newSeasonName: string, extra: Partial<Season> = {}): Promise<Season | null> => {
   const trimmedName = newSeasonName.trim();
   if (!trimmedName) {
     logger.error('[addSeason] Validation failed: Season name cannot be empty.');
@@ -62,6 +63,7 @@ export const addSeason = async (newSeasonName: string): Promise<Season | null> =
     const newSeason: Season = {
       id: `season_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
       name: trimmedName,
+      ...extra,
     };
     const updatedSeasons = [...currentSeasons, newSeason];
     const success = await saveSeasons(updatedSeasons);

--- a/src/utils/tournaments.ts
+++ b/src/utils/tournaments.ts
@@ -44,9 +44,10 @@ export const saveTournaments = async (tournaments: Tournament[]): Promise<boolea
 /**
  * Adds a new tournament to the list of tournaments in localStorage.
  * @param newTournamentName - The name of the new tournament.
+ * @param extra - Optional additional fields for the tournament.
  * @returns A promise that resolves to the newly created Tournament object, or null if validation/save fails.
  */
-export const addTournament = async (newTournamentName: string): Promise<Tournament | null> => {
+export const addTournament = async (newTournamentName: string, extra: Partial<Tournament> = {}): Promise<Tournament | null> => {
   const trimmedName = newTournamentName.trim();
   if (!trimmedName) {
     logger.error('[addTournament] Validation failed: Tournament name cannot be empty.');
@@ -62,6 +63,7 @@ export const addTournament = async (newTournamentName: string): Promise<Tourname
     const newTournament: Tournament = {
       id: `tournament_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
       name: trimmedName,
+      ...extra,
     };
     const updatedTournaments = [...currentTournaments, newTournament];
     const success = await saveTournaments(updatedTournaments);


### PR DESCRIPTION
## Summary
- extend `Season` and `Tournament` interfaces with optional fields
- allow extra fields when adding seasons or tournaments
- mark schema work as started in the enhancement plan

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872d05d8920832c870c9524402164ea