### PR TITLE
Add tasks for advanced season/tournament management

### DIFF
--- a/.docs/TODO.md
+++ b/.docs/TODO.md
@@ -102,9 +102,10 @@
   - Include notes or description fields
   - Add color or badge customization options
   - Show quick statistics like total games played and goals scored
-  - Implement import and export of season or tournament setups
+- Implement import and export of season or tournament setups
 - Offer calendar (.ics) file generation when dates are defined
   - See `season-tournament-management-plan.md` for planning details
+  - Task breakdown in `season-tournament-management-tasks.md`
 
 ## 🎨 UI/UX Improvements
 

--- a/.docs/season-tournament-management-tasks.md
+++ b/.docs/season-tournament-management-tasks.md
@@ -1,0 +1,21 @@
+# Season & Tournament Management Task List
+
+This document tracks work needed to finish the advanced management features for seasons and tournaments.
+It builds on the plan in [`season-tournament-management-plan.md`](./season-tournament-management-plan.md).
+
+## 1. Modal Form Enhancements
+- [ ] Add inputs for default game parameters (location, period count, period duration).
+- [ ] Allow entering a date range or explicit game dates for tournaments.
+- [ ] Provide an archive toggle and show quick stats (total games and goals).
+- [ ] Support notes, default roster selection and optional color/badge settings.
+
+## 2. Game Prefill Logic
+- [ ] When creating a game linked to a season or tournament, prefill settings from that entity.
+- [ ] Auto-select the default roster if one is set.
+
+## 3. Import/Export Utilities
+- [ ] Implement JSON import/export for season and tournament configurations.
+- [ ] Offer calendar (`.ics`) export when dates are defined.
+
+## Status
+- [ ] Tasks pending


### PR DESCRIPTION
## Summary
- add a new task list for the Season & Tournament management work
- reference the new file from the main TODO list

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68737fe79410832c8a9d140614518f3f