### PR TITLE
Fix tournament selection crash

### DIFF
--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -315,8 +315,9 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         });
       }
     }
-    if (s.periodCount) {
-      const count = (s.periodCount as 1 | 2) || 2;
+    const parsedCount = Number(s.periodCount);
+    if (parsedCount === 1 || parsedCount === 2) {
+      const count = parsedCount as 1 | 2;
       onNumPeriodsChange(count);
       if (currentGameId) {
         updateGameDetailsMutation.mutate({
@@ -325,12 +326,13 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         });
       }
     }
-    if (s.periodDuration) {
-      onPeriodDurationChange(s.periodDuration);
+    const parsedDuration = Number(s.periodDuration);
+    if (Number.isFinite(parsedDuration) && parsedDuration > 0) {
+      onPeriodDurationChange(parsedDuration);
       if (currentGameId) {
         updateGameDetailsMutation.mutate({
           gameId: currentGameId,
-          updates: { periodDurationMinutes: s.periodDuration },
+          updates: { periodDurationMinutes: parsedDuration },
         });
       }
     }
@@ -356,8 +358,9 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         });
       }
     }
-    if (t.periodCount) {
-      const count = (t.periodCount as 1 | 2) || 2;
+    const parsedCount = Number(t.periodCount);
+    if (parsedCount === 1 || parsedCount === 2) {
+      const count = parsedCount as 1 | 2;
       onNumPeriodsChange(count);
       if (currentGameId) {
         updateGameDetailsMutation.mutate({
@@ -366,12 +369,13 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
         });
       }
     }
-    if (t.periodDuration) {
-      onPeriodDurationChange(t.periodDuration);
+    const parsedDuration = Number(t.periodDuration);
+    if (Number.isFinite(parsedDuration) && parsedDuration > 0) {
+      onPeriodDurationChange(parsedDuration);
       if (currentGameId) {
         updateGameDetailsMutation.mutate({
           gameId: currentGameId,
-          updates: { periodDurationMinutes: t.periodDuration },
+          updates: { periodDurationMinutes: parsedDuration },
         });
       }
     }


### PR DESCRIPTION
## Summary
- normalize period count and duration when pre-filling settings from a season or tournament

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873f4611650832c8f12b5160071a3c3