### PR TITLE
Add tournament metadata support

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -61,6 +61,9 @@ export interface AppState {
   assessments?: { [playerId: string]: PlayerAssessment };
   seasonId: string;
   tournamentId: string;
+  tournamentLevel?: string;
+  /** Age group for the game, independent of tournament/season */
+  ageGroup?: string;
   /** Difficulty weighting factor for demand-correction averages */
   demandFactor?: number;
   gameLocation?: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,6 +52,8 @@ export interface Tournament {
   notes?: string;
   color?: string;
   badge?: string;
+  level?: string;
+  ageGroup?: string;
 }
 
 export * from './playerAssessment';

--- a/src/utils/appStateSchema.ts
+++ b/src/utils/appStateSchema.ts
@@ -88,6 +88,8 @@ export const appStateSchema = z.object({
   assessments: z.record(z.string(), playerAssessmentSchema).optional(),
   seasonId: z.string(),
   tournamentId: z.string(),
+  tournamentLevel: z.string().optional(),
+  ageGroup: z.string().optional(),
   gameLocation: z.string().optional(),
   gameTime: z.string().optional(),
   subIntervalMinutes: z.number().optional(),

--- a/src/utils/savedGames.ts
+++ b/src/utils/savedGames.ts
@@ -174,6 +174,8 @@ export const createGame = async (gameData: Partial<AppState>): Promise<{ gameId:
       assessments: gameData.assessments || {},
       seasonId: gameData.seasonId || '',
       tournamentId: gameData.tournamentId || '',
+      tournamentLevel: gameData.tournamentLevel || '',
+      ageGroup: gameData.ageGroup || '',
       gameLocation: gameData.gameLocation || '',
       gameTime: gameData.gameTime || '',
       tacticalDiscs: gameData.tacticalDiscs || [],


### PR DESCRIPTION
## Summary
- allow tournaments to track `level` and `ageGroup`
- persist tournament metadata in saved games
- handle new metadata in tournament helpers
- track game age group for all matches

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68741723430c832cb201eb800c8422b9