### PR TITLE
Improve dropdown placeholders

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -500,6 +500,8 @@
     "levelKilpa": "Competition",
     "levelHaaste": "Challenger",
     "levelHarraste": "Recreational",
+    "selectAgeGroup": "-- Select Age Group --",
+    "selectLevel": "-- Select Level --",
     "player": "Player",
     "record": "Record",
     "remove": "Remove",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -491,6 +491,8 @@
     "levelKilpa": "Kilpa",
     "levelHaaste": "Haaste",
     "levelHarraste": "Harraste",
+    "selectAgeGroup": "-- Valitse ikäluokka --",
+    "selectLevel": "-- Valitse taso --",
     "player": "Pelaaja",
     "record": "Rekordi",
     "remove": "Poista",

--- a/src/components/SeasonTournamentManagementModal.tsx
+++ b/src/components/SeasonTournamentManagementModal.tsx
@@ -199,7 +199,7 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                             onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,ageGroup:e.target.value})):setNewTournamentFields(f=>({...f,ageGroup:e.target.value}))}
                             className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white focus:ring-indigo-500 focus:border-indigo-500"
                         >
-                            <option value="">{t('common.none', 'None')}</option>
+                            <option value="">{t('common.selectAgeGroup', '-- Select Age Group --')}</option>
                             {AGE_GROUPS.map(group => (
                                 <option key={group} value={group}>{group}</option>
                             ))}
@@ -210,7 +210,7 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                                 onChange={e=>setNewTournamentFields(f=>({...f,level:e.target.value}))}
                                 className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white focus:ring-indigo-500 focus:border-indigo-500"
                             >
-                                <option value="">{t('common.none', 'None')}</option>
+                                <option value="">{t('common.selectLevel', '-- Select Level --')}</option>
                                 {LEVELS.map(lvl => (
                                     <option key={lvl} value={lvl}>{t(`common.level${lvl}` as TranslationKey, lvl)}</option>
                                 ))}
@@ -250,14 +250,14 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                                     <input type="text" value={editingName} onChange={(e)=>setEditingName(e.target.value)} className="w-full px-2 py-1 bg-slate-700 border border-indigo-500 rounded-md text-white" />
                                     <input type="text" value={editingFields.location || ''} onChange={(e)=>setEditingFields(f=>({...f,location:e.target.value}))} placeholder={t('seasonTournamentModal.locationLabel')} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" />
                                     <select value={editingFields.ageGroup || ''} onChange={e=>setEditingFields(f=>({...f,ageGroup:e.target.value}))} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white">
-                                        <option value="">{t('common.none', 'None')}</option>
+                                        <option value="">{t('common.selectAgeGroup', '-- Select Age Group --')}</option>
                                         {AGE_GROUPS.map(group => (
                                             <option key={group} value={group}>{group}</option>
                                         ))}
                                     </select>
                                     {type==='tournament' && (
                                         <select value={editingFields.level || ''} onChange={e=>setEditingFields(f=>({...f,level:e.target.value}))} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white">
-                                            <option value="">{t('common.none', 'None')}</option>
+                                            <option value="">{t('common.selectLevel', '-- Select Level --')}</option>
                                             {LEVELS.map(lvl => (
                                                 <option key={lvl} value={lvl}>{t(`common.level${lvl}` as TranslationKey, lvl)}</option>
                                             ))}

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -56,6 +56,8 @@ export type TranslationKey =
   | 'common.scorer'
   | 'common.season'
   | 'common.select'
+  | 'common.selectAgeGroup'
+  | 'common.selectLevel'
   | 'common.stats'
   | 'common.ties'
   | 'common.time'


### PR DESCRIPTION
## Summary
- add `selectAgeGroup` and `selectLevel` translations
- use these placeholders when creating/editing seasons and tournaments
- regenerate i18n types

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874b688bd74832cb2a612c95e40b351