### PR TITLE
Update Finnish load game text

### DIFF
--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -27,7 +27,7 @@
   "controlBar.languageToggle": "Vaihda kieli englannin (EN) ja suomen (FI) välillä.",
   "controlBar.tasoLink": "Taso",
   "controlBar.saveGameAs": "Tallenna Peli Nimellä...",
-  "controlBar.loadGame": "Lataa Peli...",
+  "controlBar.loadGame": "Tallennetut pelit",
   "controlBar.startNewGame": "Aloita uusi ottelu",
   "controlBar.startNewGameConfirm": "Haluatko varmasti aloittaa uuden ottelun? Nykyisen ottelun tallentamattomat tiedot menetetään.",
   "controlBar.hardReset": "Nollaa Sovellus",
@@ -262,7 +262,7 @@
     "noNotes": "Ei muistiinpanoja"
   },
   "loadGameModal": {
-    "title": "Lataa Peli",
+    "title": "Tallennetut pelit",
     "loadButtonTooltip": "Lataa tämä peli",
     "deleteButtonTooltip": "Poista tallennettu peli",
     "deleteConfirm": "Haluatko varmasti poistaa tallennetun pelin \"{gameName}\"? Toimintoa ei voi peruuttaa.",


### PR DESCRIPTION
## Summary
- update `controlBar.loadGame` text in Finnish translation
- rename `loadGameModal.title` to match
- regenerate i18n types

## Testing
- `npm run generate:i18n-types`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874ecd18e00832c8be5034bfad251c1