### PR TITLE
Kick off Supabase migration

### DIFF
--- a/.docs/supabase_migration_plan.md
+++ b/.docs/supabase_migration_plan.md
@@ -31,10 +31,10 @@ Migrate the entire persistence layer to Supabase, enabling multi‑user, real‑
 
 ## Step‑by‑Step Execution Plan
 
-### Core Steps  
-- [ ] **1 — Inventory Current Data**
-  - [ ] Parse codebase for every `localStorage.*` usage
-  - [ ] Generate `/docs/localStorage-map.json` with keys & samples
+### Core Steps
+- [x] **1 — Inventory Current Data**
+  - [x] Parse codebase for every `localStorage.*` usage
+  - [x] Generate `/docs/localStorage-map.json` with keys & samples
 
 - [ ] **2 — Design Supabase Schema**
   - [ ] Infer TS interfaces (Game, Player, Stats, Settings…)

--- a/docs/localStorage-map.json
+++ b/docs/localStorage-map.json
@@ -1,0 +1,63 @@
+{
+  "soccerSeasons": [
+    {
+      "id": "season_1",
+      "name": "Sample Season"
+    }
+  ],
+  "soccerTournaments": [
+    {
+      "id": "tournament_1",
+      "name": "Sample Tournament"
+    }
+  ],
+  "savedSoccerGames": {
+    "game_1": {
+      "teamName": "Team A",
+      "opponentName": "Team B",
+      "playersOnField": [],
+      "opponents": [],
+      "drawings": [],
+      "availablePlayers": [],
+      "showPlayerNames": true,
+      "gameEvents": [],
+      "gameDate": "2024-01-01",
+      "homeScore": 0,
+      "awayScore": 0,
+      "gameNotes": "",
+      "homeOrAway": "home",
+      "numberOfPeriods": 2,
+      "periodDurationMinutes": 45,
+      "currentPeriod": 1,
+      "gameStatus": "notStarted",
+      "selectedPlayerIds": [],
+      "seasonId": "season_1",
+      "tournamentId": "tournament_1",
+      "tacticalDiscs": [],
+      "tacticalDrawings": [],
+      "tacticalBallPosition": null
+    }
+  },
+  "soccerAppSettings": {
+    "currentGameId": null,
+    "lastHomeTeamName": "",
+    "language": "en",
+    "hasSeenAppGuide": false,
+    "autoBackupEnabled": false,
+    "autoBackupIntervalHours": 24,
+    "useDemandCorrection": false
+  },
+  "soccerMasterRoster": [
+    {
+      "id": "player_1",
+      "name": "Sample Player"
+    }
+  ],
+  "lastHomeTeamName": "FC Sample",
+  "soccerTimerState": {
+    "gameId": "game_1",
+    "timeElapsedInSeconds": 0,
+    "timestamp": 1752494829206
+  },
+  "installPromptDismissed": "1752494829206"
+}

--- a/scripts/generate-localStorage-map.mjs
+++ b/scripts/generate-localStorage-map.mjs
@@ -1,0 +1,65 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+async function getStorageKeys() {
+  const file = await fs.readFile(path.join('src','config','storageKeys.ts'),'utf8');
+  const regex = /export const (\w+) = '([^']+)'/g;
+  const keys = {};
+  let match;
+  while ((match = regex.exec(file))) {
+    keys[match[2]] = match[1];
+  }
+  // Additional hard-coded keys not in storageKeys.ts
+  keys['installPromptDismissed'] = 'INSTALL_PROMPT_DISMISSED';
+  return keys;
+}
+
+async function generateSampleData() {
+  return {
+    soccerSeasons: [
+      { id: 'season_1', name: 'Sample Season' }
+    ],
+    soccerTournaments: [
+      { id: 'tournament_1', name: 'Sample Tournament' }
+    ],
+    savedSoccerGames: {
+      game_1: { teamName: 'Team A', opponentName: 'Team B', playersOnField: [], opponents: [], drawings: [], availablePlayers: [], showPlayerNames: true, gameEvents: [], gameDate: '2024-01-01', homeScore: 0, awayScore: 0, gameNotes: '', homeOrAway: 'home', numberOfPeriods: 2, periodDurationMinutes: 45, currentPeriod: 1, gameStatus: 'notStarted', selectedPlayerIds: [], seasonId: 'season_1', tournamentId: 'tournament_1', tacticalDiscs: [], tacticalDrawings: [], tacticalBallPosition: null }
+    },
+    soccerAppSettings: {
+      currentGameId: null,
+      lastHomeTeamName: '',
+      language: 'en',
+      hasSeenAppGuide: false,
+      autoBackupEnabled: false,
+      autoBackupIntervalHours: 24,
+      lastBackupTime: undefined,
+      useDemandCorrection: false
+    },
+    soccerMasterRoster: [
+      { id: 'player_1', name: 'Sample Player' }
+    ],
+    lastHomeTeamName: 'FC Sample',
+    soccerTimerState: {
+      gameId: 'game_1',
+      timeElapsedInSeconds: 0,
+      timestamp: Date.now()
+    },
+    installPromptDismissed: Date.now().toString()
+  };
+}
+
+async function main() {
+  const keys = await getStorageKeys();
+  const samples = await generateSampleData();
+  const map = {};
+  for (const [key] of Object.entries(keys)) {
+    map[key] = samples[key] ?? null;
+  }
+  await fs.mkdir('docs', { recursive: true });
+  await fs.writeFile(path.join('docs','localStorage-map.json'), JSON.stringify(map, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- inventory localStorage usage and generate `localStorage-map.json`
- mark step 1 complete in the Supabase migration plan
- add script to regenerate the map automatically

## Testing
- `npm run lint`
- `npm test -- -w 1 src/utils/bytes.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6874e40a2284832c9811291f7a35df9e