### PR TITLE
Make warmup plan default section

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -20,7 +20,7 @@
   "controlBar.timerControls": "Start/stop/reset the match timer.",
   "controlBar.appGuide": "App Guide",
   "controlBar.settings": "Settings",
-  "controlBar.training": "Training",
+  "controlBar.training": "Warmup Plan",
   "controlBar.logGoal": "Log Goal",
   "controlBar.enterFullscreen": "Enter Fullscreen",
   "controlBar.exitFullscreen": "Exit Fullscreen",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -20,7 +20,7 @@
   "controlBar.timerControls": "Käynnistä/pysäytä/nollaa otteluajastin.",
   "controlBar.appGuide": "Käyttöohjeet",
   "controlBar.settings": "Asetukset",
-  "controlBar.training": "Harjoitusmateriaalit",
+  "controlBar.training": "L\u00e4mmittelysuunnitelma",
   "controlBar.logGoal": "Kirjaa maali",
   "controlBar.enterFullscreen": "Siirry koko näyttöön",
   "controlBar.exitFullscreen": "Poistu koko näytöstä",

--- a/src/components/TrainingResourcesModal.tsx
+++ b/src/components/TrainingResourcesModal.tsx
@@ -9,11 +9,11 @@ interface TrainingResourcesModalProps {
   onClose: () => void;
 }
 
-type TrainingSection = 'warmup' | 'exampleDrills';
+type TrainingSection = 'warmup';
 
 const TrainingResourcesModal: React.FC<TrainingResourcesModalProps> = ({ isOpen, onClose }) => {
   const { t } = useTranslation();
-  const [expandedSection, setExpandedSection] = useState<TrainingSection | null>(null);
+  const [expandedSection, setExpandedSection] = useState<TrainingSection | null>('warmup');
 
   if (!isOpen) return null;
 
@@ -55,7 +55,6 @@ const TrainingResourcesModal: React.FC<TrainingResourcesModalProps> = ({ isOpen,
 
   const sections: { key: TrainingSection; titleKey: string }[] = [
     { key: 'warmup', titleKey: 'trainingResourcesModal.navWarmup' },
-    { key: 'exampleDrills', titleKey: 'trainingResourcesModal.navExampleDrills' },
   ];
 
   return (
@@ -117,17 +116,6 @@ const TrainingResourcesModal: React.FC<TrainingResourcesModalProps> = ({ isOpen,
                           <ul className="list-disc list-inside space-y-1.5 pl-2">{renderListItems(t('warmup.duringGamePoints', { returnObjects: true }) as ListItem[], 's6')}</ul>
                           </section>
                         </div>
-                    )}
-                    {section.key === 'exampleDrills' && (
-                      <div className="space-y-4">
-                         <h3 className="text-xl font-semibold text-yellow-300">{t('trainingResourcesModal.exampleDrills.title')}</h3>
-                         <p className="text-slate-300">{t('trainingResourcesModal.exampleDrills.description')}</p>
-                         <ul className="list-disc list-inside space-y-1 pl-2 text-slate-300">
-                             <li>{t('trainingResourcesModal.exampleDrills.point1')}</li>
-                             <li>{t('trainingResourcesModal.exampleDrills.point2')}</li>
-                             <li>{t('trainingResourcesModal.exampleDrills.point3')}</li>
-                           </ul>
-                      </div>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- change menu label to Warmup Plan
- remove example drills from Training Resources modal
- expand warmup section by default

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687578e5d13c832c8e1b3a7d198e3f60