### PR TITLE
Apply input style across app

### DIFF
--- a/.docs/STYLE_GUIDE.md
+++ b/.docs/STYLE_GUIDE.md
@@ -75,6 +75,13 @@ Our theme combines deep, professional slate backgrounds with subtle gradients an
   border-slate-500 rounded
   focus:ring-indigo-500
   ```
+- **Text Inputs:**
+  ```css
+  block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm
+  py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2
+  focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white
+  ```
+  Used for all editable text fields such as the team name input in `RosterSettingsModal`.
 
 ## 4. List Items
 - **Container:**

--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -15,6 +15,7 @@ import { TFunction } from 'i18next';
 import AssessmentSlider from './AssessmentSlider';
 import { AGE_GROUPS, LEVELS } from '@/config/gameOptions';
 import type { TranslationKey } from '@/i18n-types';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 export type GameEventType = 'goal' | 'opponentGoal' | 'substitution' | 'periodEnd' | 'gameEnd' | 'fairPlayCard';
 
@@ -159,6 +160,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
 }) => {
   // logger.log('[GameSettingsModal Render] Props received:', { seasonId, tournamentId, currentGameId });
   const { t } = useTranslation();
+  const inputStyle = inputBaseStyle;
 
   // State for event editing within the modal
   const [localGameEvents, setLocalGameEvents] = useState<GameEvent[]>(gameEvents);
@@ -843,7 +845,9 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                 id="teamNameInput"
                 value={teamName}
                 onChange={(e) => onTeamNameChange(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={
+                  `${inputStyle} placeholder-slate-400`
+                }
                 placeholder={t('gameSettingsModal.teamNamePlaceholder', 'Enter team name')}
               />
             </div>
@@ -858,7 +862,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                 id="opponentNameInput"
                 value={opponentName}
                 onChange={(e) => onOpponentNameChange(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={`${inputStyle} placeholder-slate-400`}
                 placeholder={t('gameSettingsModal.opponentNamePlaceholder', 'Enter opponent name')}
               />
             </div>
@@ -914,7 +918,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="seasonSelect"
                       value={seasonId || ''}
                       onChange={handleSeasonChange}
-                      className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} flex-1`}
                     >
                       <option value="">{t('gameSettingsModal.selectSeason', '-- Select Season --')}</option>
                       {seasons.map((season) => (
@@ -942,7 +946,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                         onChange={(e) => setNewSeasonName(e.target.value)}
                         onKeyDown={handleNewSeasonKeyDown}
                         placeholder={t('gameSettingsModal.newSeasonPlaceholder', 'Enter new season name...')}
-                        className="flex-1 min-w-[200px] px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputStyle} flex-1 min-w-[200px] placeholder-slate-400`}
                         disabled={isAddingSeason}
                       />
                       <div className="flex gap-2 shrink-0">
@@ -976,7 +980,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="tournamentSelect"
                       value={tournamentId || ''}
                       onChange={handleTournamentChange}
-                      className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} flex-1`}
                     >
                       <option value="">{t('gameSettingsModal.selectTournament', '-- Select Tournament --')}</option>
                       {tournaments.map((tournament) => (
@@ -1004,7 +1008,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                         onChange={(e) => setNewTournamentName(e.target.value)}
                         onKeyDown={handleNewTournamentKeyDown}
                         placeholder={t('gameSettingsModal.newTournamentPlaceholder', 'Enter new tournament name...')}
-                        className="flex-1 min-w-[200px] px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputStyle} flex-1 min-w-[200px] placeholder-slate-400`}
                         disabled={isAddingTournament}
                       />
                       <div className="flex gap-2 shrink-0">
@@ -1045,7 +1049,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     updateGameDetailsMutation.mutate({ gameId: currentGameId, updates: { ageGroup: e.target.value } });
                   }
                 }}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={inputStyle}
               >
                 <option value="">{t('common.none', 'None')}</option>
                 {AGE_GROUPS.map((group) => (
@@ -1072,7 +1076,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     id="gameDateInput"
                     value={gameDate}
                     onChange={(e) => onGameDateChange(e.target.value)}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                    className={inputStyle}
                   />
                 </div>
 
@@ -1089,7 +1093,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       value={gameHour}
                       onChange={handleHourChange}
                       placeholder={t('gameSettingsModal.hourPlaceholder', 'HH')}
-                      className="w-1/2 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} w-1/2 placeholder-slate-400`}
                       maxLength={2}
                     />
                     <span className="text-slate-400">:</span>
@@ -1100,7 +1104,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       value={gameMinute}
                       onChange={handleMinuteChange}
                       placeholder={t('gameSettingsModal.minutePlaceholder', 'MM')}
-                      className="w-1/2 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} w-1/2 placeholder-slate-400`}
                       maxLength={2}
                     />
                   </div>
@@ -1117,7 +1121,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     value={gameLocation}
                     onChange={(e) => onGameLocationChange(e.target.value)}
                     placeholder={t('gameSettingsModal.locationPlaceholder', 'e.g., Central Park Field 2')}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                    className={`${inputStyle} placeholder-slate-400`}
                   />
                 </div>
 
@@ -1135,7 +1139,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                         updateGameDetailsMutation.mutate({ gameId: currentGameId, updates: { tournamentLevel: e.target.value } });
                       }
                     }}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                    className={inputStyle}
                   >
                     <option value="">{t('common.none', 'None')}</option>
                     {LEVELS.map((lvl) => (
@@ -1193,7 +1197,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="numPeriodsSelect"
                       value={numPeriods}
                       onChange={(e) => onNumPeriodsChange(parseInt(e.target.value) as 1 | 2)}
-                      className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={inputStyle}
                     >
                       <option value={1}>1</option>
                       <option value={2}>2</option>
@@ -1210,7 +1214,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="periodDurationInput"
                       value={periodDurationMinutes}
                       onChange={(e) => onPeriodDurationChange(parseInt(e.target.value, 10))}
-                      className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={inputStyle}
                       min="1"
                     />
                   </div>
@@ -1252,7 +1256,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       <select
                         value={availablePlayers.find(p => p.receivedFairPlayCard)?.id || ''}
                         onChange={(e) => handleFairPlayCardClick(e.target.value || null)}
-                        className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputStyle} flex-1`}
                       >
                         <option value="">{t('gameSettingsModal.selectPlayerForFairPlay', '-- Select Player --')}</option>
                         {availablePlayers.map((player) => (
@@ -1374,14 +1378,14 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                           value={editGoalTime}
                           onChange={(e) => setEditGoalTime(e.target.value)}
                           placeholder={t('gameSettingsModal.timeFormatPlaceholder', 'MM:SS')}
-                          className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                          className={`${inputStyle} placeholder-slate-400`}
                         />
                         {event.type === 'goal' && (
                           <>
                             <select
                               value={editGoalScorerId}
                               onChange={(e) => setEditGoalScorerId(e.target.value)}
-                              className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm appearance-none"
+                              className={`${inputStyle} appearance-none`}
                             >
                               <option value="">{t('gameSettingsModal.selectScorer', 'Select Scorer...')}</option>
                               {availablePlayers.map(player => (
@@ -1391,7 +1395,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                             <select
                               value={editGoalAssisterId}
                               onChange={(e) => setEditGoalAssisterId(e.target.value || undefined)}
-                              className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm appearance-none"
+                              className={`${inputStyle} appearance-none`}
                             >
                               <option value="">{t('gameSettingsModal.selectAssister', 'Select Assister (Optional)...')}</option>
                               {availablePlayers.map(player => (
@@ -1467,7 +1471,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     value={inlineEditValue}
                     onChange={(e) => setInlineEditValue(e.target.value)}
                     onKeyDown={handleInlineEditKeyDown}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm h-32 resize-none"
+                    className={`${inputStyle} h-32 resize-none placeholder-slate-400`}
                     placeholder={t('gameSettingsModal.notesPlaceholder', 'Write notes...')}
                     disabled={isProcessing}
                   />

--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next';
 import type { TranslationKey } from '@/i18n-types';
 import logger from '@/utils/logger';
+import { inputBaseStyle } from '@/styles/styleConstants';
 // Import types from the types directory
 import { Player, PlayerStatRow, Season, Tournament } from '@/types';
 import { GameEvent, SavedGamesCollection } from '@/types';
@@ -128,6 +129,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
   onGameClick = () => {},
 }) => {
   const { t, i18n } = useTranslation();
+  const inputStyle = inputBaseStyle;
 
   // <<< ADD DIAGNOSTIC LOG >>>
   // logger.log('[GameStatsModal Render] gameEvents prop:', JSON.stringify(gameEvents));
@@ -941,13 +943,13 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
               </div>
 
               {activeTab === 'season' && (
-                <select value={selectedSeasonIdFilter} onChange={(e) => setSelectedSeasonIdFilter(e.target.value)} className="w-full mt-2 bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                <select value={selectedSeasonIdFilter} onChange={(e) => setSelectedSeasonIdFilter(e.target.value)} className={`${inputStyle} mt-2 px-3 py-1.5 text-sm w-full bg-slate-700 border-slate-600`}>
                   <option value="all">{t('gameStatsModal.filterAllSeasons')}</option>
                   {seasons.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
                 </select>
               )}
               {activeTab === 'tournament' && (
-                <select value={selectedTournamentIdFilter} onChange={(e) => setSelectedTournamentIdFilter(e.target.value)} className="w-full mt-2 bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                <select value={selectedTournamentIdFilter} onChange={(e) => setSelectedTournamentIdFilter(e.target.value)} className={`${inputStyle} mt-2 px-3 py-1.5 text-sm w-full bg-slate-700 border-slate-600`}>
                   <option value="all">{t('gameStatsModal.filterAllTournaments')}</option>
                   {tournaments.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
                 </select>
@@ -970,7 +972,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                       const newSelectedPlayer = availablePlayers.find(p => p.id === e.target.value) || null;
                       setSelectedPlayer(newSelectedPlayer);
                     }}
-                    className="w-full bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className={`${inputStyle} px-3 py-1.5 text-sm w-full`}
                   >
                     <option value="" disabled>{t('playerStats.selectPlayer', 'Select a player to view their stats.')}</option>
                     {availablePlayers.map(p => (
@@ -1221,7 +1223,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                       value={filterText}
                       onChange={handleFilterChange}
                       placeholder={t('common.filterByName', 'Filter by name...')}
-                      className="bg-slate-800 border border-slate-700 rounded-md text-white pl-8 pr-3 py-1.5 text-sm w-full focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                      className={`${inputStyle} pl-8 pr-3 py-1.5 text-sm bg-slate-800 border-slate-700`}
                     />
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -1296,21 +1298,21 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                                   <div>
                                     <label className="block text-xs font-medium text-slate-400 mb-1">{t('common.time', 'Time')}</label>
-                                    <input 
-                                      type="text" 
-                                      value={editGoalTime} 
-                                      onChange={e => setEditGoalTime(e.target.value)} 
+                                    <input
+                                      type="text"
+                                      value={editGoalTime}
+                                      onChange={e => setEditGoalTime(e.target.value)}
                                       onKeyDown={handleGoalEditKeyDown}
                                       placeholder="MM:SS"
-                                      className="w-full bg-slate-700 border border-slate-600 rounded-md px-2 py-1.5 text-sm"
+                                      className={`${inputStyle} px-2 py-1.5 text-sm`}
                                     />
                                   </div>
                                   <div>
                                     <label className="block text-xs font-medium text-slate-400 mb-1">{t('common.scorer', 'Scorer')}</label>
-                                    <select 
-                                      value={editGoalScorerId} 
+                                    <select
+                                      value={editGoalScorerId}
                                       onChange={e => setEditGoalScorerId(e.target.value)}
-                                      className="w-full bg-slate-700 border border-slate-600 rounded-md px-2 py-1.5 text-sm"
+                                      className={`${inputStyle} px-2 py-1.5 text-sm`}
                                     >
                                       <option value="">{t('common.select', 'Select...')}</option>
                                       {availablePlayers.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
@@ -1318,10 +1320,10 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                                   </div>
                                   <div>
                                     <label className="block text-xs font-medium text-slate-400 mb-1">{t('common.assist', 'Assist')}</label>
-                                    <select 
-                                      value={editGoalAssisterId} 
+                                    <select
+                                      value={editGoalAssisterId}
                                       onChange={e => setEditGoalAssisterId(e.target.value || '')}
-                                      className="w-full bg-slate-700 border border-slate-600 rounded-md px-2 py-1.5 text-sm"
+                                      className={`${inputStyle} px-2 py-1.5 text-sm`}
                                     >
                                       <option value="">{t('common.none', 'None')}</option>
                                       {availablePlayers.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
@@ -1370,7 +1372,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                         </div>
                       </div>
                        {isEditingNotes ? (
-                          <textarea ref={notesTextareaRef} value={editGameNotes} onChange={(e) => setEditGameNotes(e.target.value)} className="w-full h-24 p-2 bg-slate-700 border border-slate-500 rounded-md shadow-sm text-sm text-slate-100 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" placeholder={t('gameStatsModal.notesPlaceholder', 'Notes...') ?? undefined} />
+                          <textarea ref={notesTextareaRef} value={editGameNotes} onChange={(e) => setEditGameNotes(e.target.value)} className={`${inputStyle} h-24 p-2 text-sm text-slate-100`} placeholder={t('gameStatsModal.notesPlaceholder', 'Notes...') ?? undefined} />
                       ) : (
                           <div className="min-h-[6rem] p-2 text-sm text-slate-300 whitespace-pre-wrap">
                               {gameNotes || <span className="italic text-slate-400">{t('gameStatsModal.noNotes', 'No notes.')}</span>}

--- a/src/components/RosterSettingsModal.tsx
+++ b/src/components/RosterSettingsModal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-icons/hi2';
 import { useTranslation } from 'react-i18next';
 import logger from '@/utils/logger';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface RosterSettingsModalProps {
   isOpen: boolean;
@@ -267,7 +268,6 @@ const RosterSettingsModal: React.FC<RosterSettingsModalProps> = ({
   const titleStyle = "text-3xl font-bold text-yellow-400 tracking-wide";
   const cardStyle = "bg-slate-900/70 p-4 rounded-lg border border-slate-700 shadow-inner";
   const labelStyle = "text-sm font-medium text-slate-300 mb-1";
-  const inputBaseStyle = "block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white";
   const buttonBaseStyle = "px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed";
   const primaryButtonStyle = `${buttonBaseStyle} bg-gradient-to-b from-indigo-500 to-indigo-600 text-white hover:from-indigo-600 hover:to-indigo-700 shadow-lg`;
   const secondaryButtonStyle = `${buttonBaseStyle} bg-gradient-to-b from-slate-600 to-slate-700 text-slate-200 hover:from-slate-700 hover:to-slate-600`;

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatBytes } from '@/utils/bytes';
 import packageJson from '../../package.json';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -70,8 +71,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   const titleStyle =
     'text-3xl font-bold text-yellow-400 tracking-wide drop-shadow-lg';
   const labelStyle = 'text-sm font-medium text-slate-300 mb-1';
-  const inputStyle =
-    'block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white';
+  const inputStyle = inputBaseStyle;
   const buttonStyle =
     'px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed';
   const primaryButtonStyle =

--- a/src/components/TimerOverlay.tsx
+++ b/src/components/TimerOverlay.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'; // Import translation hook
 import { IntervalLog } from '@/types'; // Import the IntervalLog interface
 import { formatTime } from '@/utils/time';
 import logger from '@/utils/logger';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 
 interface TimerOverlayProps {
@@ -64,6 +65,7 @@ const TimerOverlay: React.FC<TimerOverlayProps> = ({
   isLoaded,
 }) => {
   const { t } = useTranslation(); // Initialize translation hook
+  const inputStyle = inputBaseStyle;
 
   // --- State for Opponent Name Editing ---
   const [isEditingOpponentName, setIsEditingOpponentName] = useState(false);
@@ -192,7 +194,7 @@ const TimerOverlay: React.FC<TimerOverlayProps> = ({
                     onChange={handleOpponentInputChange}
                     onBlur={handleSaveOpponentName} // Save on blur
                     onKeyDown={handleOpponentKeyDown}
-                    className="bg-slate-700 text-slate-100 text-xl font-semibold outline-none rounded px-2 py-0.5 w-28" // Adjust width as needed
+                    className={`${inputStyle} text-xl font-semibold w-28`} // Adjust width as needed
                     onClick={(e) => e.stopPropagation()} // Prevent triggering underlying handlers
                 />
             ) : (

--- a/src/styles/styleConstants.ts
+++ b/src/styles/styleConstants.ts
@@ -1,0 +1,2 @@
+export const inputBaseStyle = "block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white";
+


### PR DESCRIPTION
## Summary
- document text input style in style guide
- centralize inputBaseStyle
- refactor various components to reuse inputBaseStyle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876b294f8e0832c8b75e5c954273478