### PR TITLE
Apply input style across app

### DIFF
--- a/.docs/STYLE_GUIDE.md
+++ b/.docs/STYLE_GUIDE.md
@@ -75,6 +75,14 @@ Our theme combines deep, professional slate backgrounds with subtle gradients an
   border-slate-500 rounded
   focus:ring-indigo-500
   ```
+- **Text Inputs:**
+  ```css
+  block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm
+  py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2
+  focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white
+  ```
+  Used for all editable text fields such as the team name input in `RosterSettingsModal`.
+  The team name field shows a pencil icon when not editing; other inputs reuse the same styling without the icon.
 
 ## 4. List Items
 - **Container:**

--- a/src/components/GameInfoBar.tsx
+++ b/src/components/GameInfoBar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useRef } from 'react';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface GameInfoBarProps {
   teamName: string;
@@ -92,7 +93,7 @@ const GameInfoBar: React.FC<GameInfoBarProps> = ({
     }
   };
 
-  const inputClasses = "bg-transparent border-none outline-none text-slate-100 text-sm font-medium px-1 py-0 focus:bg-slate-700 rounded";
+  const inputClasses = `${inputBaseStyle} bg-transparent border-none px-1 py-0 text-sm font-medium`;
 
   const leftTeamName = homeOrAway === 'home' ? teamName : opponentName;
   const rightTeamName = homeOrAway === 'home' ? opponentName : teamName;

--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -15,6 +15,7 @@ import { TFunction } from 'i18next';
 import AssessmentSlider from './AssessmentSlider';
 import { AGE_GROUPS, LEVELS } from '@/config/gameOptions';
 import type { TranslationKey } from '@/i18n-types';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 export type GameEventType = 'goal' | 'opponentGoal' | 'substitution' | 'periodEnd' | 'gameEnd' | 'fairPlayCard';
 
@@ -159,6 +160,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
 }) => {
   // logger.log('[GameSettingsModal Render] Props received:', { seasonId, tournamentId, currentGameId });
   const { t } = useTranslation();
+  const inputStyle = inputBaseStyle;
 
   // State for event editing within the modal
   const [localGameEvents, setLocalGameEvents] = useState<GameEvent[]>(gameEvents);
@@ -843,7 +845,9 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                 id="teamNameInput"
                 value={teamName}
                 onChange={(e) => onTeamNameChange(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={
+                  `${inputStyle} placeholder-slate-400`
+                }
                 placeholder={t('gameSettingsModal.teamNamePlaceholder', 'Enter team name')}
               />
             </div>
@@ -858,7 +862,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                 id="opponentNameInput"
                 value={opponentName}
                 onChange={(e) => onOpponentNameChange(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={`${inputStyle} placeholder-slate-400`}
                 placeholder={t('gameSettingsModal.opponentNamePlaceholder', 'Enter opponent name')}
               />
             </div>
@@ -914,7 +918,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="seasonSelect"
                       value={seasonId || ''}
                       onChange={handleSeasonChange}
-                      className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} flex-1`}
                     >
                       <option value="">{t('gameSettingsModal.selectSeason', '-- Select Season --')}</option>
                       {seasons.map((season) => (
@@ -942,7 +946,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                         onChange={(e) => setNewSeasonName(e.target.value)}
                         onKeyDown={handleNewSeasonKeyDown}
                         placeholder={t('gameSettingsModal.newSeasonPlaceholder', 'Enter new season name...')}
-                        className="flex-1 min-w-[200px] px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputStyle} flex-1 min-w-[200px] placeholder-slate-400`}
                         disabled={isAddingSeason}
                       />
                       <div className="flex gap-2 shrink-0">
@@ -976,7 +980,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="tournamentSelect"
                       value={tournamentId || ''}
                       onChange={handleTournamentChange}
-                      className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} flex-1`}
                     >
                       <option value="">{t('gameSettingsModal.selectTournament', '-- Select Tournament --')}</option>
                       {tournaments.map((tournament) => (
@@ -1004,7 +1008,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                         onChange={(e) => setNewTournamentName(e.target.value)}
                         onKeyDown={handleNewTournamentKeyDown}
                         placeholder={t('gameSettingsModal.newTournamentPlaceholder', 'Enter new tournament name...')}
-                        className="flex-1 min-w-[200px] px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputStyle} flex-1 min-w-[200px] placeholder-slate-400`}
                         disabled={isAddingTournament}
                       />
                       <div className="flex gap-2 shrink-0">
@@ -1045,7 +1049,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     updateGameDetailsMutation.mutate({ gameId: currentGameId, updates: { ageGroup: e.target.value } });
                   }
                 }}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={inputStyle}
               >
                 <option value="">{t('common.none', 'None')}</option>
                 {AGE_GROUPS.map((group) => (
@@ -1072,7 +1076,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     id="gameDateInput"
                     value={gameDate}
                     onChange={(e) => onGameDateChange(e.target.value)}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                    className={inputStyle}
                   />
                 </div>
 
@@ -1089,7 +1093,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       value={gameHour}
                       onChange={handleHourChange}
                       placeholder={t('gameSettingsModal.hourPlaceholder', 'HH')}
-                      className="w-1/2 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} w-1/2 placeholder-slate-400`}
                       maxLength={2}
                     />
                     <span className="text-slate-400">:</span>
@@ -1100,7 +1104,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       value={gameMinute}
                       onChange={handleMinuteChange}
                       placeholder={t('gameSettingsModal.minutePlaceholder', 'MM')}
-                      className="w-1/2 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={`${inputStyle} w-1/2 placeholder-slate-400`}
                       maxLength={2}
                     />
                   </div>
@@ -1117,7 +1121,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     value={gameLocation}
                     onChange={(e) => onGameLocationChange(e.target.value)}
                     placeholder={t('gameSettingsModal.locationPlaceholder', 'e.g., Central Park Field 2')}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                    className={`${inputStyle} placeholder-slate-400`}
                   />
                 </div>
 
@@ -1135,7 +1139,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                         updateGameDetailsMutation.mutate({ gameId: currentGameId, updates: { tournamentLevel: e.target.value } });
                       }
                     }}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                    className={inputStyle}
                   >
                     <option value="">{t('common.none', 'None')}</option>
                     {LEVELS.map((lvl) => (
@@ -1193,7 +1197,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="numPeriodsSelect"
                       value={numPeriods}
                       onChange={(e) => onNumPeriodsChange(parseInt(e.target.value) as 1 | 2)}
-                      className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={inputStyle}
                     >
                       <option value={1}>1</option>
                       <option value={2}>2</option>
@@ -1210,7 +1214,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       id="periodDurationInput"
                       value={periodDurationMinutes}
                       onChange={(e) => onPeriodDurationChange(parseInt(e.target.value, 10))}
-                      className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                      className={inputStyle}
                       min="1"
                     />
                   </div>
@@ -1252,7 +1256,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                       <select
                         value={availablePlayers.find(p => p.receivedFairPlayCard)?.id || ''}
                         onChange={(e) => handleFairPlayCardClick(e.target.value || null)}
-                        className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputStyle} flex-1`}
                       >
                         <option value="">{t('gameSettingsModal.selectPlayerForFairPlay', '-- Select Player --')}</option>
                         {availablePlayers.map((player) => (
@@ -1374,14 +1378,14 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                           value={editGoalTime}
                           onChange={(e) => setEditGoalTime(e.target.value)}
                           placeholder={t('gameSettingsModal.timeFormatPlaceholder', 'MM:SS')}
-                          className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                          className={`${inputStyle} placeholder-slate-400`}
                         />
                         {event.type === 'goal' && (
                           <>
                             <select
                               value={editGoalScorerId}
                               onChange={(e) => setEditGoalScorerId(e.target.value)}
-                              className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm appearance-none"
+                              className={`${inputStyle} appearance-none`}
                             >
                               <option value="">{t('gameSettingsModal.selectScorer', 'Select Scorer...')}</option>
                               {availablePlayers.map(player => (
@@ -1391,7 +1395,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                             <select
                               value={editGoalAssisterId}
                               onChange={(e) => setEditGoalAssisterId(e.target.value || undefined)}
-                              className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm appearance-none"
+                              className={`${inputStyle} appearance-none`}
                             >
                               <option value="">{t('gameSettingsModal.selectAssister', 'Select Assister (Optional)...')}</option>
                               {availablePlayers.map(player => (
@@ -1467,7 +1471,7 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                     value={inlineEditValue}
                     onChange={(e) => setInlineEditValue(e.target.value)}
                     onKeyDown={handleInlineEditKeyDown}
-                    className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm h-32 resize-none"
+                    className={`${inputStyle} h-32 resize-none placeholder-slate-400`}
                     placeholder={t('gameSettingsModal.notesPlaceholder', 'Write notes...')}
                     disabled={isProcessing}
                   />

--- a/src/components/GameStatsModal.tsx
+++ b/src/components/GameStatsModal.tsx
@@ -4,6 +4,7 @@ import React, { useMemo, useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next';
 import type { TranslationKey } from '@/i18n-types';
 import logger from '@/utils/logger';
+import { inputBaseStyle } from '@/styles/styleConstants';
 // Import types from the types directory
 import { Player, PlayerStatRow, Season, Tournament } from '@/types';
 import { GameEvent, SavedGamesCollection } from '@/types';
@@ -128,6 +129,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
   onGameClick = () => {},
 }) => {
   const { t, i18n } = useTranslation();
+  const inputStyle = inputBaseStyle;
 
   // <<< ADD DIAGNOSTIC LOG >>>
   // logger.log('[GameStatsModal Render] gameEvents prop:', JSON.stringify(gameEvents));
@@ -941,13 +943,13 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
               </div>
 
               {activeTab === 'season' && (
-                <select value={selectedSeasonIdFilter} onChange={(e) => setSelectedSeasonIdFilter(e.target.value)} className="w-full mt-2 bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                <select value={selectedSeasonIdFilter} onChange={(e) => setSelectedSeasonIdFilter(e.target.value)} className={`${inputStyle} mt-2 px-3 py-1.5 text-sm w-full bg-slate-700 border-slate-600`}>
                   <option value="all">{t('gameStatsModal.filterAllSeasons')}</option>
                   {seasons.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
                 </select>
               )}
               {activeTab === 'tournament' && (
-                <select value={selectedTournamentIdFilter} onChange={(e) => setSelectedTournamentIdFilter(e.target.value)} className="w-full mt-2 bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                <select value={selectedTournamentIdFilter} onChange={(e) => setSelectedTournamentIdFilter(e.target.value)} className={`${inputStyle} mt-2 px-3 py-1.5 text-sm w-full bg-slate-700 border-slate-600`}>
                   <option value="all">{t('gameStatsModal.filterAllTournaments')}</option>
                   {tournaments.map(t => <option key={t.id} value={t.id}>{t.name}</option>)}
                 </select>
@@ -970,7 +972,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                       const newSelectedPlayer = availablePlayers.find(p => p.id === e.target.value) || null;
                       setSelectedPlayer(newSelectedPlayer);
                     }}
-                    className="w-full bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                    className={`${inputStyle} px-3 py-1.5 text-sm w-full`}
                   >
                     <option value="" disabled>{t('playerStats.selectPlayer', 'Select a player to view their stats.')}</option>
                     {availablePlayers.map(p => (
@@ -1221,7 +1223,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                       value={filterText}
                       onChange={handleFilterChange}
                       placeholder={t('common.filterByName', 'Filter by name...')}
-                      className="bg-slate-800 border border-slate-700 rounded-md text-white pl-8 pr-3 py-1.5 text-sm w-full focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                      className={`${inputStyle} pl-8 pr-3 py-1.5 text-sm bg-slate-800 border-slate-700`}
                     />
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -1296,21 +1298,21 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                                   <div>
                                     <label className="block text-xs font-medium text-slate-400 mb-1">{t('common.time', 'Time')}</label>
-                                    <input 
-                                      type="text" 
-                                      value={editGoalTime} 
-                                      onChange={e => setEditGoalTime(e.target.value)} 
+                                    <input
+                                      type="text"
+                                      value={editGoalTime}
+                                      onChange={e => setEditGoalTime(e.target.value)}
                                       onKeyDown={handleGoalEditKeyDown}
                                       placeholder="MM:SS"
-                                      className="w-full bg-slate-700 border border-slate-600 rounded-md px-2 py-1.5 text-sm"
+                                      className={`${inputStyle} px-2 py-1.5 text-sm`}
                                     />
                                   </div>
                                   <div>
                                     <label className="block text-xs font-medium text-slate-400 mb-1">{t('common.scorer', 'Scorer')}</label>
-                                    <select 
-                                      value={editGoalScorerId} 
+                                    <select
+                                      value={editGoalScorerId}
                                       onChange={e => setEditGoalScorerId(e.target.value)}
-                                      className="w-full bg-slate-700 border border-slate-600 rounded-md px-2 py-1.5 text-sm"
+                                      className={`${inputStyle} px-2 py-1.5 text-sm`}
                                     >
                                       <option value="">{t('common.select', 'Select...')}</option>
                                       {availablePlayers.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
@@ -1318,10 +1320,10 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                                   </div>
                                   <div>
                                     <label className="block text-xs font-medium text-slate-400 mb-1">{t('common.assist', 'Assist')}</label>
-                                    <select 
-                                      value={editGoalAssisterId} 
+                                    <select
+                                      value={editGoalAssisterId}
                                       onChange={e => setEditGoalAssisterId(e.target.value || '')}
-                                      className="w-full bg-slate-700 border border-slate-600 rounded-md px-2 py-1.5 text-sm"
+                                      className={`${inputStyle} px-2 py-1.5 text-sm`}
                                     >
                                       <option value="">{t('common.none', 'None')}</option>
                                       {availablePlayers.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
@@ -1370,7 +1372,7 @@ const GameStatsModal: React.FC<GameStatsModalProps> = ({
                         </div>
                       </div>
                        {isEditingNotes ? (
-                          <textarea ref={notesTextareaRef} value={editGameNotes} onChange={(e) => setEditGameNotes(e.target.value)} className="w-full h-24 p-2 bg-slate-700 border border-slate-500 rounded-md shadow-sm text-sm text-slate-100 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500" placeholder={t('gameStatsModal.notesPlaceholder', 'Notes...') ?? undefined} />
+                          <textarea ref={notesTextareaRef} value={editGameNotes} onChange={(e) => setEditGameNotes(e.target.value)} className={`${inputStyle} h-24 p-2 text-sm text-slate-100`} placeholder={t('gameStatsModal.notesPlaceholder', 'Notes...') ?? undefined} />
                       ) : (
                           <div className="min-h-[6rem] p-2 text-sm text-slate-300 whitespace-pre-wrap">
                               {gameNotes || <span className="italic text-slate-400">{t('gameStatsModal.noNotes', 'No notes.')}</span>}

--- a/src/components/LoadGameModal.tsx
+++ b/src/components/LoadGameModal.tsx
@@ -27,6 +27,7 @@ import { exportFullBackup, importFullBackup } from '@/utils/fullBackup';
 // Import new utility functions
 import { getSeasons as utilGetSeasons } from '@/utils/seasons';
 import { getTournaments as utilGetTournaments } from '@/utils/tournaments';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 export interface LoadGameModalProps {
   isOpen: boolean;
@@ -484,7 +485,7 @@ const LoadGameModal: React.FC<LoadGameModalProps> = ({
         </div>
         <div className="px-6 py-4 backdrop-blur-sm bg-slate-900/20 border-b border-slate-700/20 flex-shrink-0">
           <div className="relative">
-            <input type="text" placeholder={t('loadGameModal.filterPlaceholder', 'Filter by name, date, etc...')} value={searchText} onChange={handleSearchChange} className="w-full pl-10 pr-4 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500" />
+            <input type="text" placeholder={t('loadGameModal.filterPlaceholder', 'Filter by name, date, etc...')} value={searchText} onChange={handleSearchChange} className={`${inputBaseStyle} pl-10 pr-4 placeholder-slate-400`} />
             <HiOutlineMagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-slate-400" />
           </div>
         </div>

--- a/src/components/NewGameSetupModal.tsx
+++ b/src/components/NewGameSetupModal.tsx
@@ -13,6 +13,7 @@ import { UseMutationResult } from '@tanstack/react-query';
 import AssessmentSlider from './AssessmentSlider';
 import { AGE_GROUPS, LEVELS } from '@/config/gameOptions';
 import type { TranslationKey } from '@/i18n-types';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface NewGameSetupModalProps {
   isOpen: boolean;
@@ -492,7 +493,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                 ref={homeTeamInputRef}
                 value={homeTeamName}
                 onChange={(e) => setHomeTeamName(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={`${inputBaseStyle} placeholder-slate-400`}
                 placeholder={t('newGameSetupModal.homeTeamPlaceholder', 'e.g., Galaxy U10')}
                 onKeyDown={handleKeyDown}
                     disabled={isLoading}
@@ -513,7 +514,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                 onChange={(e) => setOpponentName(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={t('newGameSetupModal.opponentPlaceholder', 'Enter opponent name')}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                className={`${inputBaseStyle} placeholder-slate-400`}
                 disabled={isLoading}
               />
             </div>
@@ -544,7 +545,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                             id="seasonSelect"
                             value={selectedSeasonId || ''}
                             onChange={handleSeasonChange}
-                            className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                            className={`${inputBaseStyle} flex-1`}
                           >
                             <option value="">{t('newGameSetupModal.selectSeason', '-- Select Season --')}</option>
                             {seasons.map((season) => (
@@ -572,7 +573,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                               onChange={(e) => setNewSeasonName(e.target.value)}
                               onKeyDown={handleNewSeasonKeyDown}
                               placeholder={t('newGameSetupModal.newSeasonPlaceholder', 'Enter new season name...')}
-                              className="flex-1 min-w-[200px] px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                            className={`${inputBaseStyle} flex-1 min-w-[200px] placeholder-slate-400`}
                               disabled={isAddingSeason}
                             />
                             <div className="flex gap-2 shrink-0">
@@ -607,7 +608,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                             id="tournamentSelect"
                             value={selectedTournamentId || ''}
                             onChange={handleTournamentChange}
-                            className="flex-1 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                            className={`${inputBaseStyle} flex-1`}
                           >
                             <option value="">{t('newGameSetupModal.selectTournament', '-- Select Tournament --')}</option>
                             {tournaments.map((tournament) => (
@@ -636,7 +637,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                               value={tournamentLevel}
                               onChange={(e) => setTournamentLevel(e.target.value)}
                               onKeyDown={handleKeyDown}
-                              className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                              className={`${inputBaseStyle}`} 
                               disabled={isLoading}
                             >
                               <option value="">{t('common.none', 'None')}</option>
@@ -657,7 +658,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                               onChange={(e) => setNewTournamentName(e.target.value)}
                               onKeyDown={handleNewTournamentKeyDown}
                               placeholder={t('newGameSetupModal.newTournamentPlaceholder', 'Enter new tournament name...')}
-                              className="flex-1 min-w-[200px] px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                              className={`${inputBaseStyle} flex-1 min-w-[200px] placeholder-slate-400`}
                               disabled={isAddingTournament}
                             />
                             <div className="flex gap-2 shrink-0">
@@ -693,7 +694,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                         value={ageGroup}
                         onChange={(e) => setAgeGroup(e.target.value)}
                         onKeyDown={handleKeyDown}
-                        className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputBaseStyle}`}
                         disabled={isLoading}
                       >
                         <option value="">{t('common.none', 'None')}</option>
@@ -717,7 +718,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                         value={gameDate}
                         onChange={(e) => setGameDate(e.target.value)}
                         onKeyDown={handleKeyDown}
-                        className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={inputBaseStyle}
                         disabled={isLoading}
                       />
                     </div>
@@ -734,7 +735,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                         onChange={(e) => setGameLocation(e.target.value)}
                         onKeyDown={handleKeyDown}
                         placeholder={t('newGameSetupModal.locationPlaceholder', 'e.g., Central Park Field 2')}
-                        className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                        className={`${inputBaseStyle} placeholder-slate-400`}
                         disabled={isLoading}
                       />
                     </div>
@@ -751,7 +752,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                           onChange={handleHourChange}
                           onKeyDown={handleKeyDown}
                           placeholder={t('newGameSetupModal.hourPlaceholder', 'HH')}
-                          className="w-1/2 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                          className={`${inputBaseStyle} w-1/2 placeholder-slate-400`}
                           min="0"
                           max="23"
                           disabled={isLoading}
@@ -763,7 +764,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                           onChange={handleMinuteChange}
                           onKeyDown={handleKeyDown}
                           placeholder={t('newGameSetupModal.minutePlaceholder', 'MM')}
-                          className="w-1/2 px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                          className={`${inputBaseStyle} w-1/2 placeholder-slate-400`}
                           min="0"
                           max="59"
                           disabled={isLoading}
@@ -854,7 +855,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                           id="numPeriodsSelect"
                           value={localNumPeriods}
                           onChange={(e) => setLocalNumPeriods(parseInt(e.target.value) as 1 | 2)}
-                          className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                          className={inputBaseStyle}
                         >
                           <option value={1}>1</option>
                           <option value={2}>2</option>
@@ -871,7 +872,7 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
                           id="periodDurationInput"
                           value={localPeriodDurationString}
                           onChange={(e) => setLocalPeriodDurationString(e.target.value)}
-                          className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+                          className={inputBaseStyle}
                           min="1"
                         />
                       </div>

--- a/src/components/PlayerStatsView.tsx
+++ b/src/components/PlayerStatsView.tsx
@@ -14,6 +14,7 @@ import SparklineChart from './SparklineChart';
 import RatingBar from './RatingBar';
 import MetricTrendChart from './MetricTrendChart';
 import MetricAreaChart from './MetricAreaChart';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface PlayerStatsViewProps {
   player: Player | null;
@@ -124,7 +125,7 @@ const PlayerStatsView: React.FC<PlayerStatsViewProps> = ({ player, savedGames, o
               id="metric-select"
               value={selectedMetric}
               onChange={(e) => setSelectedMetric(e.target.value)}
-              className="w-full bg-slate-700 border border-slate-600 rounded-md text-white px-3 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-indigo-500"
+              className={`${inputBaseStyle} py-1.5 text-sm`}
             >
               {metricOptions.map(opt => (
                 <option key={opt.key} value={opt.key}>{opt.label}</option>

--- a/src/components/RosterSettingsModal.tsx
+++ b/src/components/RosterSettingsModal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-icons/hi2';
 import { useTranslation } from 'react-i18next';
 import logger from '@/utils/logger';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface RosterSettingsModalProps {
   isOpen: boolean;
@@ -267,7 +268,6 @@ const RosterSettingsModal: React.FC<RosterSettingsModalProps> = ({
   const titleStyle = "text-3xl font-bold text-yellow-400 tracking-wide";
   const cardStyle = "bg-slate-900/70 p-4 rounded-lg border border-slate-700 shadow-inner";
   const labelStyle = "text-sm font-medium text-slate-300 mb-1";
-  const inputBaseStyle = "block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white";
   const buttonBaseStyle = "px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed";
   const primaryButtonStyle = `${buttonBaseStyle} bg-gradient-to-b from-indigo-500 to-indigo-600 text-white hover:from-indigo-600 hover:to-indigo-700 shadow-lg`;
   const secondaryButtonStyle = `${buttonBaseStyle} bg-gradient-to-b from-slate-600 to-slate-700 text-slate-200 hover:from-slate-700 hover:to-slate-600`;

--- a/src/components/SeasonTournamentManagementModal.tsx
+++ b/src/components/SeasonTournamentManagementModal.tsx
@@ -8,6 +8,7 @@ import { HiPlusCircle, HiOutlinePencil, HiOutlineTrash, HiOutlineCheck, HiOutlin
 import { UseMutationResult } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import RosterSelection from './RosterSelection';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface SeasonTournamentManagementModalProps {
     isOpen: boolean;
@@ -184,19 +185,19 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                             value={name}
                             onChange={(e) => setName(e.target.value)}
                             placeholder={placeholder}
-                            className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:ring-indigo-500 focus:border-indigo-500"
+                            className={`${inputBaseStyle} placeholder-slate-400 py-1.5`}
                         />
                         <input
                             type="text"
                             value={(type==='season'?newSeasonFields.location:newTournamentFields.location) || ''}
                             onChange={(e) => type==='season'?setNewSeasonFields(f=>({...f,location:e.target.value})):setNewTournamentFields(f=>({...f,location:e.target.value}))}
                             placeholder={t('seasonTournamentModal.locationLabel')}
-                            className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:ring-indigo-500 focus:border-indigo-500"
+                            className={`${inputBaseStyle} placeholder-slate-400 py-1.5`}
                         />
                         <select
                             value={(type==='season'?newSeasonFields.ageGroup:newTournamentFields.ageGroup) || ''}
                             onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,ageGroup:e.target.value})):setNewTournamentFields(f=>({...f,ageGroup:e.target.value}))}
-                            className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white focus:ring-indigo-500 focus:border-indigo-500"
+                            className={`${inputBaseStyle} py-1.5`}
                         >
                             <option value="">{t('common.selectAgeGroup', '-- Select Age Group --')}</option>
                             {AGE_GROUPS.map(group => (
@@ -207,7 +208,7 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                             <select
                                 value={newTournamentFields.level || ''}
                                 onChange={e=>setNewTournamentFields(f=>({...f,level:e.target.value}))}
-                                className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white focus:ring-indigo-500 focus:border-indigo-500"
+                                className={`${inputBaseStyle} py-1.5`}
                             >
                                 <option value="">{t('common.selectLevel', '-- Select Level --')}</option>
                                 {LEVELS.map(lvl => (
@@ -216,16 +217,16 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                             </select>
                         )}
                         <div className="grid grid-cols-2 gap-2">
-                            <input type="number" value={(type==='season'?newSeasonFields.periodCount:newTournamentFields.periodCount) || ''} onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,periodCount:parseIntOrUndefined(e.target.value)})):setNewTournamentFields(f=>({...f,periodCount:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodCountLabel')} className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:ring-indigo-500 focus:border-indigo-500" />
-                            <input type="number" value={(type==='season'?newSeasonFields.periodDuration:newTournamentFields.periodDuration) || ''} onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,periodDuration:parseIntOrUndefined(e.target.value)})):setNewTournamentFields(f=>({...f,periodDuration:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodDurationLabel')} className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:ring-indigo-500 focus:border-indigo-500" />
+                            <input type="number" value={(type==='season'?newSeasonFields.periodCount:newTournamentFields.periodCount) || ''} onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,periodCount:parseIntOrUndefined(e.target.value)})):setNewTournamentFields(f=>({...f,periodCount:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodCountLabel')} className={`${inputBaseStyle} placeholder-slate-400 py-1.5`} />
+                            <input type="number" value={(type==='season'?newSeasonFields.periodDuration:newTournamentFields.periodDuration) || ''} onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,periodDuration:parseIntOrUndefined(e.target.value)})):setNewTournamentFields(f=>({...f,periodDuration:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodDurationLabel')} className={`${inputBaseStyle} placeholder-slate-400 py-1.5`} />
                         </div>
                         {type==='tournament' && (
                             <>
-                                <input type="date" value={(newTournamentFields.startDate as string) || ''} onChange={e=>setNewTournamentFields(f=>({...f,startDate:e.target.value}))} className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white focus:ring-indigo-500 focus:border-indigo-500" placeholder={t('seasonTournamentModal.startDateLabel')} />
-                                <input type="date" value={(newTournamentFields.endDate as string) || ''} onChange={e=>setNewTournamentFields(f=>({...f,endDate:e.target.value}))} className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white focus:ring-indigo-500 focus:border-indigo-500" placeholder={t('seasonTournamentModal.endDateLabel')} />
+                                <input type="date" value={(newTournamentFields.startDate as string) || ''} onChange={e=>setNewTournamentFields(f=>({...f,startDate:e.target.value}))} className={`${inputBaseStyle} py-1.5`} placeholder={t('seasonTournamentModal.startDateLabel')} />
+                                <input type="date" value={(newTournamentFields.endDate as string) || ''} onChange={e=>setNewTournamentFields(f=>({...f,endDate:e.target.value}))} className={`${inputBaseStyle} py-1.5`} placeholder={t('seasonTournamentModal.endDateLabel')} />
                             </>
                         )}
-                        <textarea value={(type==='season'?newSeasonFields.notes:newTournamentFields.notes) || ''} onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,notes:e.target.value})):setNewTournamentFields(f=>({...f,notes:e.target.value}))} placeholder={t('seasonTournamentModal.notesLabel')} className="w-full px-3 py-1.5 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:ring-indigo-500 focus:border-indigo-500" />
+                        <textarea value={(type==='season'?newSeasonFields.notes:newTournamentFields.notes) || ''} onChange={(e)=>type==='season'?setNewSeasonFields(f=>({...f,notes:e.target.value})):setNewTournamentFields(f=>({...f,notes:e.target.value}))} placeholder={t('seasonTournamentModal.notesLabel')} className={`${inputBaseStyle} placeholder-slate-400 py-1.5`} />
                         <RosterSelection
                             players={availablePlayers}
                             selectedIds={type==='season'?newSeasonRoster:newTournamentRoster}
@@ -245,16 +246,16 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                         <div key={item.id} className="bg-slate-800/60 p-2 rounded-md">
                             {editingId === item.id ? (
                                 <div className="space-y-2">
-                                    <input type="text" value={editingName} onChange={(e)=>setEditingName(e.target.value)} className="w-full px-2 py-1 bg-slate-700 border border-indigo-500 rounded-md text-white" />
-                                    <input type="text" value={editingFields.location || ''} onChange={(e)=>setEditingFields(f=>({...f,location:e.target.value}))} placeholder={t('seasonTournamentModal.locationLabel')} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" />
-                                    <select value={editingFields.ageGroup || ''} onChange={e=>setEditingFields(f=>({...f,ageGroup:e.target.value}))} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white">
+                                    <input type="text" value={editingName} onChange={(e)=>setEditingName(e.target.value)} className={`${inputBaseStyle} py-1 px-2 border-indigo-500`} />
+                                    <input type="text" value={editingFields.location || ''} onChange={(e)=>setEditingFields(f=>({...f,location:e.target.value}))} placeholder={t('seasonTournamentModal.locationLabel')} className={`${inputBaseStyle} py-1 px-2`} />
+                                    <select value={editingFields.ageGroup || ''} onChange={e=>setEditingFields(f=>({...f,ageGroup:e.target.value}))} className={`${inputBaseStyle} py-1 px-2`}>
                                         <option value="">{t('common.selectAgeGroup', '-- Select Age Group --')}</option>
                                         {AGE_GROUPS.map(group => (
                                             <option key={group} value={group}>{group}</option>
                                         ))}
                                     </select>
                                     {type==='tournament' && (
-                                        <select value={editingFields.level || ''} onChange={e=>setEditingFields(f=>({...f,level:e.target.value}))} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white">
+                                        <select value={editingFields.level || ''} onChange={e=>setEditingFields(f=>({...f,level:e.target.value}))} className={`${inputBaseStyle} py-1 px-2`}>
                                             <option value="">{t('common.selectLevel', '-- Select Level --')}</option>
                                             {LEVELS.map(lvl => (
                                                 <option key={lvl} value={lvl}>{t(`common.level${lvl}` as TranslationKey, lvl)}</option>
@@ -262,16 +263,16 @@ const SeasonTournamentManagementModal: React.FC<SeasonTournamentManagementModalP
                                         </select>
                                     )}
                                     <div className="grid grid-cols-2 gap-2">
-                                        <input type="number" value={editingFields.periodCount || ''} onChange={(e)=>setEditingFields(f=>({...f,periodCount:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodCountLabel')} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" />
-                                        <input type="number" value={editingFields.periodDuration || ''} onChange={(e)=>setEditingFields(f=>({...f,periodDuration:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodDurationLabel')} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" />
+                                        <input type="number" value={editingFields.periodCount || ''} onChange={(e)=>setEditingFields(f=>({...f,periodCount:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodCountLabel')} className={`${inputBaseStyle} py-1 px-2`} />
+                                        <input type="number" value={editingFields.periodDuration || ''} onChange={(e)=>setEditingFields(f=>({...f,periodDuration:parseIntOrUndefined(e.target.value)}))} placeholder={t('seasonTournamentModal.periodDurationLabel')} className={`${inputBaseStyle} py-1 px-2`} />
                                     </div>
                                     {type==='tournament' && (
                                         <>
-                                            <input type="date" value={editingFields.startDate as string || ''} onChange={e=>setEditingFields(f=>({...f,startDate:e.target.value}))} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" placeholder={t('seasonTournamentModal.startDateLabel')} />
-                                            <input type="date" value={editingFields.endDate as string || ''} onChange={e=>setEditingFields(f=>({...f,endDate:e.target.value}))} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" placeholder={t('seasonTournamentModal.endDateLabel')} />
+                                            <input type="date" value={editingFields.startDate as string || ''} onChange={e=>setEditingFields(f=>({...f,startDate:e.target.value}))} className={`${inputBaseStyle} py-1 px-2`} placeholder={t('seasonTournamentModal.startDateLabel')} />
+                                            <input type="date" value={editingFields.endDate as string || ''} onChange={e=>setEditingFields(f=>({...f,endDate:e.target.value}))} className={`${inputBaseStyle} py-1 px-2`} placeholder={t('seasonTournamentModal.endDateLabel')} />
                                         </>
                                     )}
-                                    <textarea value={editingFields.notes || ''} onChange={e=>setEditingFields(f=>({...f,notes:e.target.value}))} placeholder={t('seasonTournamentModal.notesLabel')} className="w-full px-2 py-1 bg-slate-700 border border-slate-600 rounded-md text-white" />
+                                    <textarea value={editingFields.notes || ''} onChange={e=>setEditingFields(f=>({...f,notes:e.target.value}))} placeholder={t('seasonTournamentModal.notesLabel')} className={`${inputBaseStyle} py-1 px-2`} />
                                     <RosterSelection players={availablePlayers} selectedIds={editRoster} onChange={setEditRoster} />
                                     <label className="text-slate-200 text-sm flex items-center gap-1"><input type="checkbox" checked={editingFields.archived || false} onChange={e=>setEditingFields(f=>({...f,archived:e.target.checked}))} className="form-checkbox h-4 w-4" />{t('seasonTournamentModal.archiveLabel')}</label>
                                     <div className="flex justify-end gap-2">

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatBytes } from '@/utils/bytes';
 import packageJson from '../../package.json';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 interface SettingsModalProps {
   isOpen: boolean;
@@ -70,8 +71,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   const titleStyle =
     'text-3xl font-bold text-yellow-400 tracking-wide drop-shadow-lg';
   const labelStyle = 'text-sm font-medium text-slate-300 mb-1';
-  const inputStyle =
-    'block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white';
+  const inputStyle = inputBaseStyle;
   const buttonStyle =
     'px-4 py-2 rounded-md text-sm font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 disabled:opacity-50 disabled:cursor-not-allowed';
   const primaryButtonStyle =

--- a/src/components/TimerOverlay.tsx
+++ b/src/components/TimerOverlay.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next'; // Import translation hook
 import { IntervalLog } from '@/types'; // Import the IntervalLog interface
 import { formatTime } from '@/utils/time';
 import logger from '@/utils/logger';
+import { inputBaseStyle } from '@/styles/styleConstants';
 
 
 interface TimerOverlayProps {
@@ -64,6 +65,7 @@ const TimerOverlay: React.FC<TimerOverlayProps> = ({
   isLoaded,
 }) => {
   const { t } = useTranslation(); // Initialize translation hook
+  const inputStyle = inputBaseStyle;
 
   // --- State for Opponent Name Editing ---
   const [isEditingOpponentName, setIsEditingOpponentName] = useState(false);
@@ -192,7 +194,7 @@ const TimerOverlay: React.FC<TimerOverlayProps> = ({
                     onChange={handleOpponentInputChange}
                     onBlur={handleSaveOpponentName} // Save on blur
                     onKeyDown={handleOpponentKeyDown}
-                    className="bg-slate-700 text-slate-100 text-xl font-semibold outline-none rounded px-2 py-0.5 w-28" // Adjust width as needed
+                    className={`${inputStyle} text-xl font-semibold w-28`} // Adjust width as needed
                     onClick={(e) => e.stopPropagation()} // Prevent triggering underlying handlers
                 />
             ) : (

--- a/src/styles/styleConstants.ts
+++ b/src/styles/styleConstants.ts
@@ -1,0 +1,2 @@
+export const inputBaseStyle = "block w-full bg-slate-700 border border-slate-600 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 focus:ring-indigo-500 sm:text-sm text-white";
+


### PR DESCRIPTION
## Summary
- document text input style referencing the team name field
- apply `inputBaseStyle` to additional inputs in NewGameSetupModal, SeasonTournamentManagementModal, LoadGameModal, PlayerStatsView and GameInfoBar

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876b294f8e0832c8b75e5c954273478