### PR TITLE
Add resume game button to StartScreen

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -462,6 +462,7 @@
   "startScreen": {
     "startNewGame": "Start New Game",
     "loadGame": "Load Game",
+    "resumeGame": "Resume Last Game",
     "createSeasonTournament": "Create Season/Tournament",
     "viewStats": "View Stats"
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -376,6 +376,7 @@
   "startScreen": {
     "startNewGame": "Aloita uusi ottelu",
     "loadGame": "Lataa peli",
+    "resumeGame": "Jatka edellistä peliä",
     "createSeasonTournament": "Luo kausi/turnaus",
     "viewStats": "Näytä tilastot"
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,13 +3,34 @@
 import ModalProvider from '@/contexts/ModalProvider';
 import HomePage from '@/components/HomePage';
 import StartScreen from '@/components/StartScreen';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { getCurrentGameIdSetting } from '@/utils/appSettings';
+import { getSavedGames } from '@/utils/savedGames';
 
 export default function Home() {
   const [screen, setScreen] = useState<'start' | 'home'>('start');
-  const [initialAction, setInitialAction] = useState<'newGame' | 'loadGame' | 'season' | 'stats' | null>(null);
+  const [initialAction, setInitialAction] = useState<'newGame' | 'loadGame' | 'resumeGame' | 'season' | 'stats' | null>(null);
+  const [canResume, setCanResume] = useState(false);
 
-  const handleAction = (action: 'newGame' | 'loadGame' | 'season' | 'stats') => {
+  useEffect(() => {
+    const checkResume = async () => {
+      try {
+        const lastId = await getCurrentGameIdSetting();
+        if (!lastId) return;
+        const games = await getSavedGames();
+        if (games[lastId]) {
+          setCanResume(true);
+        }
+      } catch {
+        setCanResume(false);
+      }
+    };
+    checkResume();
+  }, []);
+
+  const handleAction = (
+    action: 'newGame' | 'loadGame' | 'resumeGame' | 'season' | 'stats'
+  ) => {
     setInitialAction(action);
     setScreen('home');
   };
@@ -20,6 +41,8 @@ export default function Home() {
         <StartScreen
           onStartNewGame={() => handleAction('newGame')}
           onLoadGame={() => handleAction('loadGame')}
+          onResumeGame={() => handleAction('resumeGame')}
+          canResume={canResume}
           onCreateSeason={() => handleAction('season')}
           onViewStats={() => handleAction('stats')}
         />

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -132,7 +132,7 @@ const initialState: AppState = {
 };
 
 interface HomePageProps {
-  initialAction?: 'newGame' | 'loadGame' | 'season' | 'stats';
+  initialAction?: 'newGame' | 'loadGame' | 'resumeGame' | 'season' | 'stats';
   skipInitialSetup?: boolean;
 }
 

--- a/src/components/StartScreen.test.tsx
+++ b/src/components/StartScreen.test.tsx
@@ -14,6 +14,7 @@ describe('StartScreen', () => {
     const handlers = {
       onStartNewGame: jest.fn(),
       onLoadGame: jest.fn(),
+      onResumeGame: jest.fn(),
       onCreateSeason: jest.fn(),
       onViewStats: jest.fn(),
     };
@@ -22,11 +23,14 @@ describe('StartScreen', () => {
       <StartScreen
         onStartNewGame={handlers.onStartNewGame}
         onLoadGame={handlers.onLoadGame}
+        onResumeGame={handlers.onResumeGame}
+        canResume
         onCreateSeason={handlers.onCreateSeason}
         onViewStats={handlers.onViewStats}
       />
     );
 
+    expect(screen.getByRole('button', { name: 'Resume Last Game' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Start New Game' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Load Game' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Season/Tournament' })).toBeInTheDocument();
@@ -34,5 +38,8 @@ describe('StartScreen', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Start New Game' }));
     expect(handlers.onStartNewGame).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resume Last Game' }));
+    expect(handlers.onResumeGame).toHaveBeenCalled();
   });
 });

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -6,35 +6,58 @@ import { useTranslation } from 'react-i18next';
 interface StartScreenProps {
   onStartNewGame: () => void;
   onLoadGame: () => void;
+  onResumeGame?: () => void;
   onCreateSeason: () => void;
   onViewStats: () => void;
+  canResume?: boolean;
 }
 
 const StartScreen: React.FC<StartScreenProps> = ({
   onStartNewGame,
   onLoadGame,
+  onResumeGame,
   onCreateSeason,
   onViewStats,
+  canResume = false,
 }) => {
   const { t } = useTranslation();
 
   const buttonStyle =
-    'px-4 py-2 rounded-md text-lg font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 bg-indigo-600 hover:bg-indigo-700 text-white w-64';
+    'px-4 py-2 rounded-md text-lg font-medium transition-colors shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-800 bg-gradient-to-b from-indigo-500 to-indigo-600 hover:from-indigo-600 hover:to-indigo-700 text-white w-64';
+
+  const containerStyle =
+    'relative flex flex-col items-center justify-center min-h-screen bg-slate-900 text-slate-100 font-display overflow-hidden';
+
+  const titleStyle = 'text-4xl font-bold text-yellow-400 tracking-wide drop-shadow-lg mb-8';
 
   return (
-    <div className="flex flex-col items-center justify-center h-screen bg-slate-900 text-slate-100 space-y-4">
-      <button className={buttonStyle} onClick={onStartNewGame}>
-        {t('startScreen.startNewGame', 'Start New Game')}
-      </button>
-      <button className={buttonStyle} onClick={onLoadGame}>
-        {t('startScreen.loadGame', 'Load Game')}
-      </button>
-      <button className={buttonStyle} onClick={onCreateSeason}>
-        {t('startScreen.createSeasonTournament', 'Create Season/Tournament')}
-      </button>
-      <button className={buttonStyle} onClick={onViewStats}>
-        {t('startScreen.viewStats', 'View Stats')}
-      </button>
+    <div className={containerStyle}>
+      <div className="absolute inset-0 bg-noise-texture" />
+      <div className="absolute inset-0 bg-indigo-600/10 mix-blend-soft-light" />
+      <div className="absolute inset-0 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent" />
+      <div className="absolute -inset-[50px] bg-sky-400/5 blur-2xl top-0 opacity-50" />
+      <div className="absolute -inset-[50px] bg-indigo-600/5 blur-2xl bottom-0 opacity-50" />
+
+      <div className="relative z-10 flex flex-col items-center space-y-4">
+        <h1 className={titleStyle}>Soccer Pre-Game</h1>
+        {canResume && onResumeGame ? (
+          <button className={buttonStyle} onClick={onResumeGame}>
+            {t('startScreen.resumeGame', 'Resume Last Game')}
+          </button>
+        ) : null}
+        <button className={buttonStyle} onClick={onStartNewGame}>
+          {t('startScreen.startNewGame', 'Start New Game')}
+        </button>
+        <button className={buttonStyle} onClick={onLoadGame}>
+          {t('startScreen.loadGame', 'Load Game')}
+        </button>
+        <button className={buttonStyle} onClick={onCreateSeason}>
+          {t('startScreen.createSeasonTournament', 'Create Season/Tournament')}
+        </button>
+        <button className={buttonStyle} onClick={onViewStats}>
+          {t('startScreen.viewStats', 'View Stats')}
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -494,6 +494,7 @@ export type TranslationKey =
   | 'settingsModal.title'
   | 'startScreen.createSeasonTournament'
   | 'startScreen.loadGame'
+  | 'startScreen.resumeGame'
   | 'startScreen.startNewGame'
   | 'startScreen.viewStats'
   | 'timerOverlay.confirmSubButton'


### PR DESCRIPTION
## Summary
- improve StartScreen styling following STYLE_GUIDE
- add optional resume game button and tests
- check for last saved game on load
- support new `resumeGame` action in HomePage
- update translations and i18n types

## Testing
- `npm run generate:i18n-types`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876bc98cd2c832ca689b85cbb48dd8f