### PR TITLE
Add modal start menu

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
 // Import Heroicons (Outline style)
 import {
     HiOutlineArrowUturnLeft,
@@ -9,27 +9,15 @@ import {
     HiOutlineBackspace, // Icon for Clear Drawings
     HiOutlineStopCircle,
     HiOutlineClock,
-    HiOutlineClipboardDocumentList, // Replaces FaClipboardList
     HiOutlineClipboard, // Icon for Tactics Board
     HiOutlineCog6Tooth, // Settings icon
-    HiOutlineBookOpen, // Import for Training Resources
-    HiOutlineArrowTopRightOnSquare, // External link icon
-    HiOutlineChevronLeft, // Chevron for Back button
     HiOutlineQuestionMarkCircle, // Icon for help
     HiOutlinePlusCircle, // Icon for adding discs
     // HiOutlineMinusCircle, // Icon for adding opponent discs
     // HiOutlineFolderArrowDown,   // Icon for Save Game As... (COMMENTED OUT)
-    HiOutlineFolderOpen,       // Icon for Load Game...
-    HiOutlineArrowPath,        // CORRECT Icon for Reset Stats
     HiOutlineUsers,            // Icon for Manage Roster
-    HiOutlineArchiveBoxArrowDown, // Use this for Quick Save
-    // ADD New Icons
     HiOutlineAdjustmentsHorizontal, // For Game Settings
-    HiOutlineDocumentArrowDown,   // For Export Data
     HiOutlineSquares2X2,       // For Place All Players on Field
-    // HiOutlineXCircle, // REMOVE unused
-    // HiOutlineRectangleGroup, // REMOVE unused
-    HiOutlineTrophy,
 } from 'react-icons/hi2'; // Using hi2 for Heroicons v2 Outline
 // REMOVE FaClock, FaUsers, FaCog (FaFutbol remains)
 import { FaFutbol } from 'react-icons/fa';
@@ -49,25 +37,17 @@ interface ControlBarProps {
   onAddOpponent: () => void;
   showLargeTimerOverlay: boolean;
   onToggleLargeTimerOverlay: () => void;
-  onToggleTrainingResources: () => void; // Add prop for training modal
   onToggleGoalLogModal: () => void; // Add prop for goal modal
-  onToggleGameStatsModal: () => void;
-  onOpenLoadGameModal: () => void; // NEW PROP
-  onStartNewGame: () => void; // CHANGED from onResetGameStats
   onOpenRosterModal: () => void; // Add prop for opening roster modal
-  onQuickSave: () => void; // Add prop for quick save
   onOpenGameSettingsModal: () => void;
-  isGameLoaded: boolean; // To enable/disable the settings button
   onPlaceAllPlayers: () => void; // New prop for placing all players on the field
   highlightRosterButton: boolean; // <<< ADD prop for highlighting
-  onOpenSeasonTournamentModal: () => void;
   isTacticsBoardView: boolean;
   onToggleTacticsBoard: () => void;
   onAddHomeDisc: () => void;
   onAddOpponentDisc: () => void;
   onToggleInstructionsModal: () => void;
-  onOpenSettingsModal: () => void;
-  onOpenPlayerAssessmentModal: () => void;
+  onOpenMenu: () => void;
 }
 
 const ControlBar: React.FC<ControlBarProps> = ({
@@ -80,30 +60,20 @@ const ControlBar: React.FC<ControlBarProps> = ({
   onAddOpponent,
   showLargeTimerOverlay,
   onToggleLargeTimerOverlay,
-  onToggleTrainingResources,
   onToggleGoalLogModal,
-  onToggleGameStatsModal,
-  onOpenLoadGameModal,
-  onStartNewGame,
   onOpenRosterModal,
-  onQuickSave,
   onOpenGameSettingsModal,
-  isGameLoaded,
   onPlaceAllPlayers,
   highlightRosterButton, // <<< Receive prop
-  onOpenSeasonTournamentModal,
   isTacticsBoardView,
   onToggleTacticsBoard,
   onAddHomeDisc,
   onAddOpponentDisc,
   onToggleInstructionsModal,
-  onOpenSettingsModal,
-  onOpenPlayerAssessmentModal,
+  onOpenMenu,
 }) => {
   const { t } = useTranslation(); // Standard hook
   logger.log('[ControlBar Render] Received highlightRosterButton prop:', highlightRosterButton); // <<< Log prop value
-  const [isSettingsMenuOpen, setIsSettingsMenuOpen] = useState(false);
-  const settingsMenuRef = useRef<HTMLDivElement>(null);
   
   // --- RE-ADD BUTTON STYLES --- 
   // Consistent Button Styles - Adjusted active state
@@ -117,43 +87,8 @@ const ControlBar: React.FC<ControlBarProps> = ({
   // --- END RE-ADD BUTTON STYLES --- 
 
 
-  const handleSettingsButtonClick = () => {
-    setIsSettingsMenuOpen(!isSettingsMenuOpen);
-  };
-
-  // Close settings menu if clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (settingsMenuRef.current && !settingsMenuRef.current.contains(event.target as Node)) {
-        setIsSettingsMenuOpen(false);
-      }
-    };
-
-    if (isSettingsMenuOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isSettingsMenuOpen]);
-
   const iconSize = "w-5 h-5"; // Standard icon size class
-  const menuIconSize = "w-5 h-5 mr-2"; // Smaller icon size for menu items
 
-  // Helper to wrap handlers to also close the menu & reset view
-  const wrapHandler = (handler: () => void) => () => {
-    handler();
-    setIsSettingsMenuOpen(false);
-  };
-
-  // Callback to handle StartNewGame button click
-  const handleStartNewGame = () => {
-    onStartNewGame();
-    setIsSettingsMenuOpen(false);
-  };
 
   return (
     <div className="bg-gradient-to-b from-slate-800 to-slate-900 p-2 shadow-md flex flex-wrap justify-center items-center gap-x-4 gap-y-2 relative z-40">
@@ -229,9 +164,6 @@ const ControlBar: React.FC<ControlBarProps> = ({
         {/* <<< ADD Game Settings Button >>> */}
         <button
             onClick={onOpenGameSettingsModal}
-            // Disable if no game is loaded? Keep enabled for consistency?
-            // Let's keep it enabled, the modal itself might handle the state.
-            // disabled={!isGameLoaded} 
             className={`${baseButtonStyle} ${secondaryColor}`}
             title={t('controlBar.gameSettings', 'Game Settings') ?? "Game Settings"}
         >
@@ -256,124 +188,14 @@ const ControlBar: React.FC<ControlBarProps> = ({
         </button>
         
         
-        {/* Settings Menu Button (REMAINING) */}
-        <div className="relative" ref={settingsMenuRef}>
-          <button
-            onClick={handleSettingsButtonClick}
-            className={`${baseButtonStyle} ${secondaryColor}`}
-            title={t('controlBar.settings') ?? "Settings"}
-          >
-            <HiOutlineCog6Tooth className={iconSize} />
-          </button>
-
-          {/* Settings Dropdown Menu (REORGANIZED) */}
-          {isSettingsMenuOpen && (
-            <div 
-               // Adjust position higher up to not overlap control bar too much
-               className={`fixed top-auto bottom-10 left-4 right-4 pt-1 pb-2 mt-auto mb-0 max-h-[85%] bg-slate-800/98 backdrop-blur-sm rounded-t-md shadow-xl z-50 border-x border-t border-slate-600/50 overflow-hidden transition-all duration-200 ease-in-out transform ${isSettingsMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-full'}`}
-            >
-               {/* Wrapper for Menu View */}
-               <div className="flex w-full transition-transform duration-200 ease-out">
-
-                   {/* --- Main Menu View --- */}
-                   <div className="w-full flex-shrink-0 overflow-y-auto max-h-[85vh]">
-                     <div className="px-3 py-2 flex justify-between items-center border-b border-slate-700/80">
-                       <h3 className="text-base font-semibold text-yellow-300">{t('controlBar.menu.title', 'Menu')}</h3>
-                       <button onClick={() => { setIsSettingsMenuOpen(false); }} className="text-slate-400 hover:text-slate-200" title={t('common.closeMenu', 'Close Menu') ?? undefined}><HiOutlineChevronLeft className="w-5 h-5"/></button>
-                     </div>
-                     <nav className="flex flex-col p-2 space-y-1 text-sm">
-                       {/* Group 1: Game Management */} 
-                       <div className="py-0.5">
-                         <button onClick={wrapHandler(onQuickSave)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                           <HiOutlineArchiveBoxArrowDown className={menuIconSize} /> {t('controlBar.saveGame', 'Save')}
-                         </button>
-                         <button onClick={wrapHandler(onOpenLoadGameModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                           <HiOutlineFolderOpen className={menuIconSize} /> {t('controlBar.loadGame', 'Load Game...')}
-                         </button>
-                         <button onClick={handleStartNewGame} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                           <HiOutlineArrowPath className={menuIconSize} /> {t('controlBar.newGameButton', 'New Game')}
-                         </button>
-                       </div>
-                       
-                       {/* Divider - slightly more visible */}
-                       <div className="my-1 border-t border-slate-600/40"></div>
-  
-                       {/* Group 2: Roster & Settings */}
-                       <div className="py-0.5">
-                         <button onClick={wrapHandler(onOpenGameSettingsModal)} className={`w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75 ${!isGameLoaded ? 'opacity-50 cursor-not-allowed' : ''}`} disabled={!isGameLoaded}>
-                           <HiOutlineAdjustmentsHorizontal className={menuIconSize} /> {t('controlBar.gameSettingsButton', 'Game Settings')}
-                         </button>
-                         <button onClick={wrapHandler(onOpenRosterModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                           <HiOutlineUsers className={menuIconSize} /> {t('controlBar.manageRoster', 'Manage Roster')}
-                         </button>
-                         <button onClick={wrapHandler(onOpenSeasonTournamentModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                            <HiOutlineTrophy className={menuIconSize} /> {t('controlBar.manageSeasonsAndTournaments', 'Manage Seasons & Tournaments')}
-                         </button>
-                       </div>
-
-                       {/* ADD Subtle Divider - slightly more visible */}
-                       <hr className="border-slate-600/40 my-1 mx-2" />
-                     
-                       {/* Group 3: Information/Export */} 
-                       <div className="py-0.5">
-                        <button onClick={wrapHandler(onToggleGameStatsModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                          <HiOutlineClipboardDocumentList className={menuIconSize} />{t('controlBar.stats', 'Stats')}
-                        </button>
-                        <button
-                          onClick={wrapHandler(onOpenPlayerAssessmentModal)}
-                          className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75"
-                          title={t('instructionsModal.controlBar.assessPlayers') ?? undefined}
-                        >
-                          <HiOutlineClipboard className={menuIconSize} />{t('controlBar.assessPlayers', 'Assess Players')}
-                        </button>
-                        <button onClick={wrapHandler(onToggleTrainingResources)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                          <HiOutlineBookOpen className={menuIconSize} />{t('controlBar.training', 'Training')}
-                        </button>
-                         {/* Coaching Materials Link (MOVED HERE AND STYLED CONSISTENTLY) */}
-                         <a
-                           href="https://www.palloliitto.fi/valmentajien-materiaalit-jalkapallo"
-                           target="_blank"
-                           rel="noopener noreferrer"
-                           onClick={() => { setIsSettingsMenuOpen(false); }} // Close menu on click
-                           className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75"
-                         >
-                           <HiOutlineArrowTopRightOnSquare className={menuIconSize} />
-                           {t('controlBar.coachingMaterials', 'Coaching Materials')} 
-                         </a>
-                         {/* Export Data - Link to Load Modal for now, as it has Export All */} 
-                         <button onClick={wrapHandler(onOpenLoadGameModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                           <HiOutlineDocumentArrowDown className={menuIconSize} />{t('controlBar.exportData', 'Export Data')}
-                         </button>
-                       </div>
-                       
-                       {/* ADD Subtle Divider - slightly more visible */}
-                       <hr className="border-slate-600/40 my-1 mx-2" />
-                       
-                       {/* Group 4: External Links */}
-                       <div className="py-0.5">
-                         <a href="https://taso.palloliitto.fi" target="_blank" rel="noopener noreferrer" className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75" onClick={wrapHandler(() => {})}>
-                           <HiOutlineArrowTopRightOnSquare className={menuIconSize} />{t('controlBar.tasoLink', 'Taso')}
-                         </a>
-                       </div>
-
-                       {/* ADD Subtle Divider - slightly more visible */}
-                       <hr className="border-slate-600/40 my-1 mx-2" />
-
-                     {/* Group 5: App Settings */}
-                     <div className="py-0.5">
-                       <button onClick={wrapHandler(onOpenSettingsModal)} className="w-full flex items-center px-3 py-1.5 text-sm text-slate-100 hover:bg-slate-600/75">
-                         <HiOutlineCog6Tooth className={menuIconSize} /> {t('controlBar.appSettings', 'App Settings')}
-                       </button>
-                     </div>
-
-                     </nav>
-                   </div>{/* End Main Menu View */}
-
-                   
-               </div> {/* End inner wrapper */} 
-            </div>
-          )}
-        </div>
+        {/* Menu Button */}
+        <button
+          onClick={onOpenMenu}
+          className={`${baseButtonStyle} ${secondaryColor}`}
+          title={t('controlBar.settings') ?? 'Settings'}
+        >
+          <HiOutlineCog6Tooth className={iconSize} />
+        </button>
       </div>
     </div>
   );

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -13,6 +13,7 @@ import NewGameSetupModal from '@/components/NewGameSetupModal';
 import RosterSettingsModal from '@/components/RosterSettingsModal';
 import GameSettingsModal from '@/components/GameSettingsModal';
 import SettingsModal from '@/components/SettingsModal';
+import StartScreen from '@/components/StartScreen';
 import SeasonTournamentManagementModal from '@/components/SeasonTournamentManagementModal';
 import InstructionsModal from '@/components/InstructionsModal';
 import PlayerAssessmentModal from '@/components/PlayerAssessmentModal';
@@ -36,6 +37,7 @@ import {
 
 // Import utility functions for seasons and tournaments
 import { saveGame as utilSaveGame, deleteGame as utilDeleteGame, getLatestGameId, createGame } from '@/utils/savedGames';
+import { getSavedGames } from '@/utils/savedGames';
 import {
   saveCurrentGameIdSetting as utilSaveCurrentGameIdSetting,
   resetAppSettings as utilResetAppSettings,
@@ -45,6 +47,7 @@ import {
   saveLastHomeTeamName as utilSaveLastHomeTeamName,
   updateAppSettings as utilUpdateAppSettings,
   getAppSettings,
+  getCurrentGameIdSetting,
 } from '@/utils/appSettings';
 import { deleteSeason as utilDeleteSeason, updateSeason as utilUpdateSeason, addSeason as utilAddSeason } from '@/utils/seasons';
 import { deleteTournament as utilDeleteTournament, updateTournament as utilUpdateTournament, addTournament as utilAddTournament } from '@/utils/tournaments';
@@ -430,6 +433,8 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
   // --- Timer State (Still needed here) ---
   const [showLargeTimerOverlay, setShowLargeTimerOverlay] = useState<boolean>(false); // State for overlay visibility
   const [isInstructionsModalOpen, setIsInstructionsModalOpen] = useState<boolean>(false);
+  const [isStartMenuOpen, setIsStartMenuOpen] = useState<boolean>(false);
+  const [canResumeGame, setCanResumeGame] = useState<boolean>(false);
 
   useEffect(() => {
     if (!initialAction) return;
@@ -1365,6 +1370,25 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
     }
     setIsInstructionsModalOpen(!isInstructionsModalOpen);
   };
+
+  useEffect(() => {
+    const checkResume = async () => {
+      try {
+        const lastId = await getCurrentGameIdSetting();
+        if (!lastId) return;
+        const games = await getSavedGames();
+        if (games[lastId]) {
+          setCanResumeGame(true);
+        }
+      } catch {
+        setCanResumeGame(false);
+      }
+    };
+    checkResume();
+  }, []);
+
+  const openStartMenu = () => setIsStartMenuOpen(true);
+  const closeStartMenu = () => setIsStartMenuOpen(false);
 
   const handleShowAppGuide = () => {
     saveHasSeenAppGuide(false);
@@ -2510,25 +2534,17 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
           onAddOpponent={handleAddOpponent}
           showLargeTimerOverlay={showLargeTimerOverlay}
           onToggleLargeTimerOverlay={handleToggleLargeTimerOverlay}
-          onToggleTrainingResources={handleToggleTrainingResources}
           onToggleGoalLogModal={handleToggleGoalLogModal}
-          onToggleGameStatsModal={handleToggleGameStatsModal}
-          onOpenLoadGameModal={handleOpenLoadGameModal}
-          onStartNewGame={handleStartNewGame}
           onOpenRosterModal={openRosterModal}
-          onQuickSave={handleQuickSaveGame}
           onOpenGameSettingsModal={handleOpenGameSettingsModal}
-          isGameLoaded={!!currentGameId && currentGameId !== DEFAULT_GAME_ID}
           onPlaceAllPlayers={handlePlaceAllPlayers}
           highlightRosterButton={highlightRosterButton}
-          onOpenSeasonTournamentModal={handleOpenSeasonTournamentModal}
           isTacticsBoardView={isTacticsBoardView}
           onToggleTacticsBoard={handleToggleTacticsBoard}
           onAddHomeDisc={() => handleAddTacticalDisc('home')}
           onAddOpponentDisc={() => handleAddTacticalDisc('opponent')}
           onToggleInstructionsModal={handleToggleInstructionsModal}
-          onOpenSettingsModal={handleOpenSettingsModal}
-          onOpenPlayerAssessmentModal={openPlayerAssessmentModal}
+          onOpenMenu={openStartMenu}
         />
       </div>
 
@@ -2743,6 +2759,43 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
         onSave={handleSavePlayerAssessment}
         onDelete={handleDeletePlayerAssessment}
       />
+
+      {isStartMenuOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-[60] font-display">
+          <StartScreen
+            onStartNewGame={() => {
+              closeStartMenu();
+              handleStartNewGame();
+            }}
+            onLoadGame={() => {
+              closeStartMenu();
+              handleOpenLoadGameModal();
+            }}
+            onResumeGame={canResumeGame ? () => {
+              closeStartMenu();
+              handleOpenLoadGameModal();
+            } : undefined}
+            canResume={canResumeGame}
+            onCreateSeason={() => {
+              closeStartMenu();
+              handleOpenSeasonTournamentModal();
+            }}
+            onViewStats={() => {
+              closeStartMenu();
+              handleToggleGameStatsModal();
+            }}
+            onAssessPlayers={() => {
+              closeStartMenu();
+              openPlayerAssessmentModal();
+            }}
+            onOpenSettings={() => {
+              closeStartMenu();
+              handleOpenSettingsModal();
+            }}
+            onClose={closeStartMenu}
+          />
+        </div>
+      )}
     </main>
   );
 }

--- a/src/components/StartScreen.test.tsx
+++ b/src/components/StartScreen.test.tsx
@@ -17,6 +17,8 @@ describe('StartScreen', () => {
       onResumeGame: jest.fn(),
       onCreateSeason: jest.fn(),
       onViewStats: jest.fn(),
+      onAssessPlayers: jest.fn(),
+      onOpenSettings: jest.fn(),
     };
 
     render(
@@ -27,6 +29,9 @@ describe('StartScreen', () => {
         canResume
         onCreateSeason={handlers.onCreateSeason}
         onViewStats={handlers.onViewStats}
+        onAssessPlayers={handlers.onAssessPlayers}
+        onOpenSettings={handlers.onOpenSettings}
+        onClose={() => {}}
       />
     );
 
@@ -35,6 +40,9 @@ describe('StartScreen', () => {
     expect(screen.getByRole('button', { name: 'Load Game' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Season/Tournament' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'View Stats' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Assess Players' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'App Settings' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Start New Game' }));
     expect(handlers.onStartNewGame).toHaveBeenCalled();

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { HiOutlineXMark } from 'react-icons/hi2';
 
 interface StartScreenProps {
   onStartNewGame: () => void;
@@ -9,6 +10,9 @@ interface StartScreenProps {
   onResumeGame?: () => void;
   onCreateSeason: () => void;
   onViewStats: () => void;
+  onAssessPlayers?: () => void;
+  onOpenSettings?: () => void;
+  onClose?: () => void;
   canResume?: boolean;
 }
 
@@ -18,6 +22,9 @@ const StartScreen: React.FC<StartScreenProps> = ({
   onResumeGame,
   onCreateSeason,
   onViewStats,
+  onAssessPlayers,
+  onOpenSettings,
+  onClose,
   canResume = false,
 }) => {
   const { t } = useTranslation();
@@ -38,6 +45,16 @@ const StartScreen: React.FC<StartScreenProps> = ({
       <div className="absolute -inset-[50px] bg-sky-400/5 blur-2xl top-0 opacity-50" />
       <div className="absolute -inset-[50px] bg-indigo-600/5 blur-2xl bottom-0 opacity-50" />
 
+      {onClose ? (
+        <button
+          onClick={onClose}
+          className="absolute top-4 right-4 text-slate-300 hover:text-white"
+          title={t('common.close', 'Close')}
+        >
+          <HiOutlineXMark className="w-8 h-8" />
+        </button>
+      ) : null}
+
       <div className="relative z-10 flex flex-col items-center space-y-4">
         <h1 className={titleStyle}>Soccer Pre-Game</h1>
         {canResume && onResumeGame ? (
@@ -57,6 +74,16 @@ const StartScreen: React.FC<StartScreenProps> = ({
         <button className={buttonStyle} onClick={onViewStats}>
           {t('startScreen.viewStats', 'View Stats')}
         </button>
+        {onAssessPlayers ? (
+          <button className={buttonStyle} onClick={onAssessPlayers}>
+            {t('controlBar.assessPlayers', 'Assess Players')}
+          </button>
+        ) : null}
+        {onOpenSettings ? (
+          <button className={buttonStyle} onClick={onOpenSettings}>
+            {t('controlBar.appSettings', 'App Settings')}
+          </button>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- repurpose StartScreen as full‑screen modal for main menu
- open menu via ControlBar button
- implement handlers in HomePage
- enhance StartScreen with close/App Settings/Assess Players buttons
- update tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876bf527ffc832cb3fde4736bf547c1