### PR TITLE
Add logo to start screen

### DIFF
--- a/.docs/Archive/hedge.md
+++ b/.docs/Archive/hedge.md
@@ -1,6 +1,6 @@
 # HEDGE - High-level Enhancement & Development Guide
 
-This document summarizes potential improvements and new feature ideas for the Soccer Pre-Game application after reviewing the current code base.
+This document summarizes potential improvements and new feature ideas for the MatchDay Coach application after reviewing the current code base.
 
 ## 1. Codebase Improvements
 

--- a/.docs/STYLE_GUIDE.md
+++ b/.docs/STYLE_GUIDE.md
@@ -1,6 +1,6 @@
 # UI/UX Style Guide
 
-This document outlines the design system and styling conventions for the Soccer Pre-Game App to ensure a cohesive and professional user experience.
+This document outlines the design system and styling conventions for the MatchDay Coach app to ensure a cohesive and professional user experience.
 
 ## 1. Color Palette & Effects
 

--- a/.docs/demo-guides/app-workflow-video-transcript.md
+++ b/.docs/demo-guides/app-workflow-video-transcript.md
@@ -1,10 +1,10 @@
 # App Workflow Screen Recording Script
 
-This short script walks through the key features of the Soccer Pre-Game app using your existing demo data. Use it as a guide while recording the phone screen.
+This short script walks through the key features of the MatchDay Coach app using your existing demo data. Use it as a guide while recording the phone screen.
 
 ## 1. Prepare and Launch
 1. Start your device's screen recording.
-2. Open **Soccer Pre-Game** from the home screen.
+2. Open **MatchDay Coach** from the home screen.
 3. From the **Start Screen**, tap **Load Game** and select a recent match.
 
 ## 2. Review the Roster

--- a/.docs/hedge-companion-app-ideas.md
+++ b/.docs/hedge-companion-app-ideas.md
@@ -1,6 +1,6 @@
 # Hedge Companion App Ideas
 
-These concepts expand on the core Soccer Pre-Game application and help hedge development efforts by diversifying the toolset available to coaches.
+These concepts expand on the core MatchDay Coach application and help hedge development efforts by diversifying the toolset available to coaches.
 
 ## 1. Training Session Planner
 - Create practice schedules, assign drills, and track attendance.

--- a/.docs/security-enhancement-plan.md
+++ b/.docs/security-enhancement-plan.md
@@ -1,6 +1,6 @@
 # Data Security Enhancement Plan
 
-This document summarizes a security audit of the Soccer Pre-Game App and outlines recommended enhancements to better protect user data stored in the browser.
+This document summarizes a security audit of the MatchDay Coach app and outlines recommended enhancements to better protect user data stored in the browser.
 
 ## 1. Current Data Handling
 

--- a/.docs/settings-modal-plan.md
+++ b/.docs/settings-modal-plan.md
@@ -1,6 +1,6 @@
 # Settings Modal Plan
 
-This document outlines the proposed Settings modal for the Soccer Pre-Game App. The project already stores a few preferences in `src/utils/appSettings.ts` but has no dedicated UI to modify them. The modal will consolidate all global options in one place and build on existing persistence utilities.
+This document outlines the proposed Settings modal for the MatchDay Coach app. The project already stores a few preferences in `src/utils/appSettings.ts` but has no dedicated UI to modify them. The modal will consolidate all global options in one place and build on existing persistence utilities.
 
 ## 1. General
 - **Language selection** – toggle language and persist via `updateAppSettings({ language })`.

--- a/.docs/showcase/app-showcase-en.md
+++ b/.docs/showcase/app-showcase-en.md
@@ -1,4 +1,4 @@
-# Soccer Pre-Game & Tactics Board
+# MatchDay Coach
 
 ## Overview
 Modern PWA that turns phones and tablets into a complete coaching assistant for match day.
@@ -7,7 +7,7 @@ Modern PWA that turns phones and tablets into a complete coaching assistant for 
 Coaches often juggle notebooks, spreadsheets and timer apps, losing valuable insights and wasting precious time on the sideline.
 
 ## Our Solution
-The Soccer Pre-Game app merges roster management, live event logging and an interactive tactics board in one streamlined interface. Plan, execute and analyze without leaving the field.
+The MatchDay Coach app merges roster management, live event logging and an interactive tactics board in one streamlined interface. Plan, execute and analyze without leaving the field.
 
 ## Key Features
 ### Match Preparation

--- a/.docs/showcase/app-showcase-fi.md
+++ b/.docs/showcase/app-showcase-fi.md
@@ -1,4 +1,4 @@
-# Soccer Pre-Game & Tactics Board
+# MatchDay Coach
 
 ## Yleiskuvaus
 Moderni PWA, joka muuttaa puhelimet ja tabletit täysiverisiksi valmentajan työkaluiksi ottelupäivänä.
@@ -7,7 +7,7 @@ Moderni PWA, joka muuttaa puhelimet ja tabletit täysiverisiksi valmentajan työ
 Valmentajat sähläävät usein muistivihkojen, taulukoiden ja ajastinsovellusten kanssa, jolloin tärkeitä havaintoja katoaa ja aikaa kuluu hukkaan kentän laidalla.
 
 ## Ratkaisumme
-Soccer Pre-Game yhdistää pelaajaluettelon hallinnan, reaaliaikaisen tapahtumakirjauksen ja interaktiivisen taktiikkataulun yhteen selkeään käyttöliittymään. Voit suunnitella, toteuttaa ja analysoida peliä poistumatta kentältä.
+MatchDay Coach yhdistää pelaajaluettelon hallinnan, reaaliaikaisen tapahtumakirjauksen ja interaktiivisen taktiikkataulun yhteen selkeään käyttöliittymään. Voit suunnitella, toteuttaa ja analysoida peliä poistumatta kentältä.
 
 ## Keskeiset ominaisuudet
 ### Otteluun valmistautuminen

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Soccer Pre-Game & Tactics Board
+# MatchDay Coach
 
 A comprehensive PWA for soccer coaches to manage rosters, track live game events, analyze detailed statistics, and design plays on an interactive tactics board. Built for the sideline, available on any device.
 

--- a/SUPABASE_MIGRATION.md
+++ b/SUPABASE_MIGRATION.md
@@ -1,6 +1,6 @@
 # Migrating to Supabase
 
-This document explains how to move the Soccer Pre-Game & Tactics Board application from storing data in browser `localStorage` to using Supabase as a backend. It assumes familiarity with the current architecture described in [README.md](./README.md) and [CLAUDE.md](./CLAUDE.md).
+This document explains how to move the MatchDay Coach application from storing data in browser `localStorage` to using Supabase as a backend. It assumes familiarity with the current architecture described in [README.md](./README.md) and [CLAUDE.md](./CLAUDE.md).
 
 ## 1. Current State Overview
 

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import Image from 'next/image';
 import { useTranslation } from 'react-i18next';
 
 interface StartScreenProps {
@@ -39,7 +40,14 @@ const StartScreen: React.FC<StartScreenProps> = ({
       <div className="absolute -inset-[50px] bg-indigo-600/5 blur-2xl bottom-0 opacity-50" />
 
       <div className="relative z-10 flex flex-col items-center space-y-4">
-        <h1 className={titleStyle}>Soccer Pre-Game</h1>
+        <Image
+          src="/pepo-logo.png"
+          alt="MatchDay Coach Logo"
+          width={128}
+          height={128}
+          className="mb-4"
+        />
+        <h1 className={titleStyle}>MatchDay Coach</h1>
         {canResume && onResumeGame ? (
           <button className={buttonStyle} onClick={onResumeGame}>
             {t('startScreen.resumeGame', 'Resume Last Game')}

--- a/src/config/manifest.config.js
+++ b/src/config/manifest.config.js
@@ -5,23 +5,23 @@
 export const manifestConfig = {
   // Config for the 'development' branch
   development: {
-    appName: "Soccer App (Dev)",
+    appName: "MatchDay Coach (Dev)",
     shortName: "Dev App",
     iconPath: "/pepo-logo-dev.png", // We will create this icon
     themeColor: "#4f46e5", // A distinct purple for dev
   },
   // Config for the 'master' branch (production)
   master: {
-    appName: "Soccer Pre-Game",
-    shortName: "Soccer App",
+    appName: "MatchDay Coach",
+    shortName: "MatchDay Coach",
     iconPath: "/pepo-logo.png",
     themeColor: "#1e293b", // The standard slate color
   },
   // A fallback for any other branch (e.g., feature branches)
   default: {
-    appName: "Soccer App (Preview)",
+    appName: "MatchDay Coach (Preview)",
     shortName: "Preview App",
     iconPath: "/pepo-logo.png",
     themeColor: "#ca8a04", // A yellow/amber for previews
   },
-}; 
+};


### PR DESCRIPTION
## Summary
- show the project logo above the main heading on the start screen
- rename the app to MatchDay Coach throughout docs and configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876c9a5c2bc832c8dba240224edeb63