### PR TITLE
Enhance start page design

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -460,6 +460,7 @@
   "noNotes": "No notes yet. Click to add."
   },
   "startScreen": {
+    "tagline": "Your Ultimate Sideline Assistant",
     "startNewGame": "Start New Game",
     "loadGame": "Load Game",
     "resumeGame": "Resume Last Game",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -374,6 +374,7 @@
   },
   "timerOverlay.subIntervalLabel": "Vaihdon Aikaväli:",
   "startScreen": {
+    "tagline": "Valmentajan ykkösapuri",
     "startNewGame": "Aloita uusi ottelu",
     "loadGame": "Lataa peli",
     "resumeGame": "Jatka edellistä peliä",

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -29,11 +29,14 @@ const StartScreen: React.FC<StartScreenProps> = ({
   const containerStyle =
     'relative flex flex-col items-center justify-center min-h-screen bg-slate-900 text-slate-100 font-display overflow-hidden';
 
+  const taglineStyle = 'text-xl text-slate-300 mb-6 text-center max-w-xs';
+
   const titleStyle = 'text-4xl font-bold text-yellow-400 tracking-wide drop-shadow-lg mb-8';
 
   return (
     <div className={containerStyle}>
       <div className="absolute inset-0 bg-noise-texture" />
+      <div className="absolute inset-0 bg-gradient-radial from-indigo-900 via-slate-900/80 to-slate-900" />
       <div className="absolute inset-0 bg-indigo-600/10 mix-blend-soft-light" />
       <div className="absolute inset-0 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent" />
       <div className="absolute -inset-[50px] bg-sky-400/5 blur-2xl top-0 opacity-50" />
@@ -45,9 +48,10 @@ const StartScreen: React.FC<StartScreenProps> = ({
           alt="MatchDay Coach Logo"
           width={128}
           height={128}
-          className="mb-4"
+          className="mb-4 animate-pulse-slow"
         />
         <h1 className={titleStyle}>MatchDay Coach</h1>
+        <p className={taglineStyle}>{t('startScreen.tagline', 'Your Ultimate Sideline Assistant')}</p>
         {canResume && onResumeGame ? (
           <button className={buttonStyle} onClick={onResumeGame}>
             {t('startScreen.resumeGame', 'Resume Last Game')}

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -496,6 +496,7 @@ export type TranslationKey =
   | 'startScreen.loadGame'
   | 'startScreen.resumeGame'
   | 'startScreen.startNewGame'
+  | 'startScreen.tagline'
   | 'startScreen.viewStats'
   | 'timerOverlay.confirmSubButton'
   | 'timerOverlay.gameEnded'


### PR DESCRIPTION
## Summary
- add tagline translations
- style StartScreen with gradient background and tagline

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876cf63d3fc832c86692a4bc6ca342f