### PR TITLE
Improve StartScreen visuals

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,19 @@ body > div {
   animation: pulse-slow 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
+@keyframes rotate-slow {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-rotate-slow {
+  animation: rotate-slow 60s linear infinite;
+}
+
 /* Flash feedback for button clicks */
 .flash-feedback {
   animation: flash 0.3s ease-out;

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -29,7 +29,8 @@ const StartScreen: React.FC<StartScreenProps> = ({
   const containerStyle =
     'relative flex flex-col items-center justify-center min-h-screen bg-slate-900 text-slate-100 font-display overflow-hidden';
 
-  const taglineStyle = 'text-xl text-slate-300 mb-6 text-center max-w-xs';
+  const taglineStyle =
+    'text-xl text-slate-300 mb-8 text-center max-w-xs drop-shadow-md';
 
   const titleStyle = 'text-4xl font-bold text-yellow-400 tracking-wide drop-shadow-lg mb-8';
 
@@ -41,6 +42,17 @@ const StartScreen: React.FC<StartScreenProps> = ({
       <div className="absolute inset-0 bg-gradient-to-b from-sky-400/10 via-transparent to-transparent" />
       <div className="absolute -inset-[50px] bg-sky-400/5 blur-2xl top-0 opacity-50" />
       <div className="absolute -inset-[50px] bg-indigo-600/5 blur-2xl bottom-0 opacity-50" />
+      <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+        <div className="relative w-[450px] h-[450px]">
+          <div className="absolute inset-0 rounded-full bg-gradient-to-b from-indigo-500/20 via-indigo-700/30 to-transparent blur-3xl" />
+          <Image
+            src="/ball.png"
+            alt=""
+            fill
+            className="object-contain opacity-5 animate-rotate-slow"
+          />
+        </div>
+      </div>
 
       <div className="relative z-10 flex flex-col items-center space-y-4">
         <Image


### PR DESCRIPTION
## Summary
- add rotating soccer ball background on StartScreen
- tweak tagline styling for extra polish
- define `rotate-slow` animation in global CSS

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876d22b0eec832ca97c51570c8dc86c