### PR TITLE
Add email backup option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The app is designed to be an all-in-one digital assistant for game day, from pre
 *   **Management Enhancements:** Store default game settings, assign default rosters, archive old competitions and view quick stats. Import or export season setups for easy reuse.
 *   **Full Backup & Restore:** Safeguard your data by exporting and importing a single file containing all players, games, and settings.
 *   **Automatic Backups:** Background process periodically saves a full backup file so your data stays safe even if you forget to export manually.
+*   **Email Backups:** Optionally send each backup file to a configured email address for off-device safety.
 *   **Save & Load Games:** Save an unlimited number of game states and load them back at any time for review or continuation.
 
 ### 🚀 Technology & Usability

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -589,6 +589,7 @@
     "backupTitle": "Automatic Backup",
     "autoBackupLabel": "Enable Automatic Backup",
     "backupIntervalLabel": "Backup Interval (hours)",
+    "backupEmailLabel": "Backup Email",
     "lastBackupLabel": "Last Backup",
     "never": "Never"
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -580,6 +580,7 @@
     "backupTitle": "Automaattinen varmuuskopio",
     "autoBackupLabel": "Ota automaattinen varmuuskopio käyttöön",
     "backupIntervalLabel": "Varmuuskopiointiväli (tuntia)",
+    "backupEmailLabel": "Varmuuskopio-sähköposti",
     "lastBackupLabel": "Viimeinen varmuuskopio",
     "never": "Ei koskaan"
   },

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -382,6 +382,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
   const [autoBackupEnabled, setAutoBackupEnabled] = useState<boolean>(false);
   const [backupIntervalHours, setBackupIntervalHours] = useState<number>(24);
   const [lastBackupTime, setLastBackupTime] = useState<string | null>(null);
+  const [backupEmail, setBackupEmail] = useState<string>('');
 
   useEffect(() => {
     utilGetLastHomeTeamName().then((name) => setDefaultTeamNameSetting(name));
@@ -394,6 +395,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
       setAutoBackupEnabled(s.autoBackupEnabled ?? false);
       setBackupIntervalHours(s.autoBackupIntervalHours ?? 24);
       setLastBackupTime(s.lastBackupTime ?? null);
+      setBackupEmail(s.backupEmail ?? '');
     });
   }, []);
 
@@ -2723,6 +2725,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
         autoBackupEnabled={autoBackupEnabled}
         backupIntervalHours={backupIntervalHours}
         lastBackupTime={lastBackupTime || undefined}
+        backupEmail={backupEmail}
         onAutoBackupEnabledChange={(enabled) => {
           setAutoBackupEnabled(enabled);
           utilUpdateAppSettings({ autoBackupEnabled: enabled }).catch(() => {});
@@ -2731,6 +2734,10 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
           const val = Math.max(1, hours);
           setBackupIntervalHours(val);
           utilUpdateAppSettings({ autoBackupIntervalHours: val }).catch(() => {});
+        }}
+        onBackupEmailChange={(email) => {
+          setBackupEmail(email);
+          utilUpdateAppSettings({ backupEmail: email }).catch(() => {});
         }}
       />
 

--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -31,6 +31,8 @@ const defaultProps = {
   lastBackupTime: '2024-01-01T00:00:00.000Z',
   onAutoBackupEnabledChange: jest.fn(),
   onBackupIntervalChange: jest.fn(),
+  backupEmail: 'coach@example.com',
+  onBackupEmailChange: jest.fn(),
 };
 
 describe('<SettingsModal />', () => {
@@ -99,5 +101,10 @@ describe('<SettingsModal />', () => {
     const intervalInput = screen.getByLabelText('Backup Interval (hours)');
     fireEvent.change(intervalInput, { target: { value: '12' } });
     expect(defaultProps.onBackupIntervalChange).toHaveBeenCalledWith(12);
+
+    const emailInput = screen.getByLabelText('Backup Email');
+    fireEvent.change(emailInput, { target: { value: 'new@example.com' } });
+    fireEvent.blur(emailInput);
+    expect(defaultProps.onBackupEmailChange).toHaveBeenCalledWith('new@example.com');
   });
 });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -19,6 +19,8 @@ interface SettingsModalProps {
   lastBackupTime?: string | null;
   onAutoBackupEnabledChange: (enabled: boolean) => void;
   onBackupIntervalChange: (hours: number) => void;
+  backupEmail: string;
+  onBackupEmailChange: (email: string) => void;
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -35,10 +37,13 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   lastBackupTime,
   onAutoBackupEnabledChange,
   onBackupIntervalChange,
+  backupEmail,
+  onBackupEmailChange,
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
   const [teamName, setTeamName] = useState(defaultTeamName);
+  const [emailValue, setEmailValue] = useState(backupEmail);
   const [resetConfirm, setResetConfirm] = useState('');
   const [storageEstimate, setStorageEstimate] = useState<{ usage: number; quota: number } | null>(null);
   const MAX_LOCAL_STORAGE = 5 * 1024 * 1024; // 5 MB assumption for localStorage
@@ -46,6 +51,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   useEffect(() => {
     setTeamName(defaultTeamName);
   }, [defaultTeamName]);
+
+  useEffect(() => {
+    setEmailValue(backupEmail);
+  }, [backupEmail]);
 
   useEffect(() => {
     if (isOpen) {
@@ -139,6 +148,17 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                   min={1}
                   value={backupIntervalHours}
                   onChange={(e) => onBackupIntervalChange(Number(e.target.value))}
+                  className={inputStyle}
+                />
+              </div>
+              <div>
+                <label htmlFor="backup-email" className={labelStyle}>{t('settingsModal.backupEmailLabel', 'Backup Email')}</label>
+                <input
+                  id="backup-email"
+                  type="email"
+                  value={emailValue}
+                  onChange={(e) => setEmailValue(e.target.value)}
+                  onBlur={() => onBackupEmailChange(emailValue)}
                   className={inputStyle}
                 />
               </div>

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -473,6 +473,7 @@ export type TranslationKey =
   | 'settingsModal.aboutTitle'
   | 'settingsModal.appVersion'
   | 'settingsModal.autoBackupLabel'
+  | 'settingsModal.backupEmailLabel'
   | 'settingsModal.backupIntervalLabel'
   | 'settingsModal.backupTitle'
   | 'settingsModal.confirmResetLabel'

--- a/src/utils/appSettings.test.ts
+++ b/src/utils/appSettings.test.ts
@@ -51,6 +51,7 @@ describe('App Settings Utilities', () => {
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
         lastBackupTime: undefined,
+        backupEmail: '',
         useDemandCorrection: false
       });
     });
@@ -70,6 +71,7 @@ describe('App Settings Utilities', () => {
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
         lastBackupTime: undefined,
+        backupEmail: '',
         useDemandCorrection: false
       });
     });
@@ -89,6 +91,7 @@ describe('App Settings Utilities', () => {
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
         lastBackupTime: undefined,
+        backupEmail: '',
         useDemandCorrection: false
       });
       
@@ -111,6 +114,7 @@ describe('App Settings Utilities', () => {
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
         lastBackupTime: undefined,
+        backupEmail: '',
         useDemandCorrection: false
       });
       consoleSpy.mockRestore();
@@ -170,6 +174,7 @@ describe('App Settings Utilities', () => {
         autoBackupEnabled: false,
         autoBackupIntervalHours: 24,
         lastBackupTime: undefined,
+        backupEmail: '',
         useDemandCorrection: false
       });
       
@@ -183,6 +188,7 @@ describe('App Settings Utilities', () => {
           autoBackupEnabled: false,
           autoBackupIntervalHours: 24,
           lastBackupTime: undefined,
+          backupEmail: '',
           useDemandCorrection: false
         })
       );
@@ -261,6 +267,7 @@ describe('App Settings Utilities', () => {
           hasSeenAppGuide: false,
           autoBackupEnabled: false,
           autoBackupIntervalHours: 24,
+          backupEmail: '',
           useDemandCorrection: false
         })
       );
@@ -346,6 +353,7 @@ describe('App Settings Utilities', () => {
         expect(savedSettings).toEqual({
           ...currentSettings, // Ensure other settings are preserved
           lastHomeTeamName: 'New Team Name', // The updated value
+          backupEmail: '',
           useDemandCorrection: false
         });
       }
@@ -388,6 +396,7 @@ describe('App Settings Utilities', () => {
           autoBackupEnabled: false,
           autoBackupIntervalHours: 24,
           lastBackupTime: undefined,
+          backupEmail: '',
           useDemandCorrection: false
         })
       );

--- a/src/utils/appSettings.ts
+++ b/src/utils/appSettings.ts
@@ -23,6 +23,7 @@ export interface AppSettings {
   autoBackupEnabled?: boolean;
   autoBackupIntervalHours?: number;
   lastBackupTime?: string;
+  backupEmail?: string;
   useDemandCorrection?: boolean;
   // Add other settings as needed
 }
@@ -38,6 +39,7 @@ const DEFAULT_APP_SETTINGS: AppSettings = {
   autoBackupEnabled: false,
   autoBackupIntervalHours: 24,
   lastBackupTime: undefined,
+  backupEmail: '',
   useDemandCorrection: false,
 };
 

--- a/src/utils/emailBackup.ts
+++ b/src/utils/emailBackup.ts
@@ -1,0 +1,23 @@
+import logger from './logger';
+
+export const sendBackupEmail = async (file: Blob, email: string): Promise<void> => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file, 'backup.json');
+    formData.append('email', email);
+
+    const res = await fetch('/api/send-backup', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!res.ok) {
+      throw new Error(`Server responded with ${res.status}`);
+    }
+  } catch (error) {
+    logger.error('Failed to send backup email:', error);
+    throw error;
+  }
+};
+
+export default sendBackupEmail;

--- a/src/utils/fullBackup.ts
+++ b/src/utils/fullBackup.ts
@@ -9,6 +9,8 @@ import {
   MASTER_ROSTER_KEY
 } from '@/config/storageKeys';
 import logger from '@/utils/logger';
+import { getAppSettings } from '@/utils/appSettings';
+import sendBackupEmail from '@/utils/emailBackup';
 // Import the new async localStorage utility functions
 import {
   getLocalStorageItem,
@@ -87,6 +89,16 @@ export const exportFullBackup = async (): Promise<void> => {
     URL.revokeObjectURL(url);
     logger.log(`Full backup exported successfully as ${a.download}`);
     alert('Full backup exported successfully!'); // Provide user feedback
+
+    const settings = await getAppSettings();
+    if (settings.backupEmail) {
+      try {
+        await sendBackupEmail(blob, settings.backupEmail);
+        logger.log(`Backup emailed to ${settings.backupEmail}`);
+      } catch (err) {
+        logger.error('Failed to send backup email:', err);
+      }
+    }
 
   } catch (error) {
     logger.error("Failed to export full backup:", error);


### PR DESCRIPTION
## Summary
- support backupEmail in app settings
- show backup email field in SettingsModal
- auto email backup file if address configured
- test email backup flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876d168e0d0832c99c46eb00be4da44