### PR TITLE
Fix email backup encoding and persist backup email

### DIFF
--- a/src/app/api/send-backup/route.ts
+++ b/src/app/api/send-backup/route.ts
@@ -1,7 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import sgMail from '@sendgrid/mail';
 
-sgMail.setApiKey(process.env.SENDGRID_API_KEY || '');
+export const runtime = 'nodejs';
+
+const apiKey = process.env.SENDGRID_API_KEY;
+if (!apiKey) {
+  console.error('SENDGRID_API_KEY not set');
+}
+sgMail.setApiKey(apiKey || '');
 
 export async function POST(req: NextRequest) {
   try {

--- a/src/utils/appSettings.test.ts
+++ b/src/utils/appSettings.test.ts
@@ -194,6 +194,36 @@ describe('App Settings Utilities', () => {
       );
     });
 
+    it('should update the backup email', async () => {
+      const currentSettings: AppSettings = {
+        currentGameId: 'game123',
+        lastHomeTeamName: 'Team A',
+        language: 'en',
+        hasSeenAppGuide: false,
+        autoBackupEnabled: false,
+        autoBackupIntervalHours: 24,
+      };
+      localStorageMock.getItem.mockReturnValue(JSON.stringify(currentSettings));
+
+      const result = await updateAppSettings({ backupEmail: 'a@test.com' });
+
+      expect(result).toEqual({
+        ...currentSettings,
+        lastBackupTime: undefined,
+        backupEmail: 'a@test.com',
+        useDemandCorrection: false,
+      });
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        APP_SETTINGS_KEY,
+        JSON.stringify({
+          ...currentSettings,
+          lastBackupTime: undefined,
+          backupEmail: 'a@test.com',
+          useDemandCorrection: false,
+        })
+      );
+    });
+
     it('should throw an error if update fails', async () => {
       const currentSettings: AppSettings = {
         currentGameId: 'initialGame',

--- a/src/utils/sendBackupEmail.ts
+++ b/src/utils/sendBackupEmail.ts
@@ -1,3 +1,12 @@
+import { Buffer } from 'buffer';
+
+const toBase64 = (data: string): string => {
+  if (typeof window === 'undefined') {
+    return Buffer.from(data, 'utf8').toString('base64');
+  }
+  return btoa(unescape(encodeURIComponent(data)));
+};
+
 export const sendBackupEmail = async (json: string, email: string): Promise<void> => {
   const filename = `SoccerApp_Backup_${new Date()
     .toISOString()
@@ -5,7 +14,7 @@ export const sendBackupEmail = async (json: string, email: string): Promise<void
   const res = await fetch('/api/send-backup', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, filename, content: btoa(json) }),
+    body: JSON.stringify({ email, filename, content: toBase64(json) }),
   });
   if (!res.ok) {
     throw new Error('Email send failed');


### PR DESCRIPTION
## Summary
- support Unicode in `sendBackupEmail`
- ensure the `/api/send-backup` route runs on Node.js and warns if the API key is missing
- test that updating backup email persists the value

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68795d31f4ac832c9a68c606786dec2c