### PR TITLE
Fix auto focus in settings modal

### DIFF
--- a/src/components/SettingsModal.test.tsx
+++ b/src/components/SettingsModal.test.tsx
@@ -109,4 +109,10 @@ describe('<SettingsModal />', () => {
 
     rerender(<SettingsModal {...defaultProps} backupEmail="a@test.com" />);
   });
+
+  test('does not auto focus team name input on open', () => {
+    render(<SettingsModal {...defaultProps} />);
+    const input = screen.getByLabelText('Default Team Name');
+    expect(input).not.toHaveFocus();
+  });
 });

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatBytes } from '@/utils/bytes';
 import packageJson from '../../package.json';
@@ -43,7 +43,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onSendBackup,
 }) => {
   const { t } = useTranslation();
-  const inputRef = useRef<HTMLInputElement>(null);
   const [teamName, setTeamName] = useState(defaultTeamName);
   const [resetConfirm, setResetConfirm] = useState('');
   const [storageEstimate, setStorageEstimate] = useState<{ usage: number; quota: number } | null>(null);
@@ -55,7 +54,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
 
   useEffect(() => {
     if (isOpen) {
-      setTimeout(() => inputRef.current?.focus(), 100);
       if (navigator.storage?.estimate) {
         navigator.storage
           .estimate()
@@ -114,7 +112,6 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
               <label htmlFor="team-name-input" className={labelStyle}>{t('settingsModal.defaultTeamNameLabel', 'Default Team Name')}</label>
               <input
                 id="team-name-input"
-                ref={inputRef}
                 type="text"
                 value={teamName}
                 onChange={(e) => setTeamName(e.target.value)}


### PR DESCRIPTION
## Summary
- stop focusing the default team input when opening the settings modal
- test that the team name field is not focused by default

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68796bb77694832cb89ec8e69b7cf36e