### PR TITLE
Improve backup sharing

### DIFF
--- a/src/utils/sendBackupEmail.test.ts
+++ b/src/utils/sendBackupEmail.test.ts
@@ -1,0 +1,56 @@
+import { sendBackupEmail } from './sendBackupEmail';
+
+// Mock window.location
+const originalLocation = window.location;
+delete (window as unknown as { location?: Location }).location;
+window.location = { href: '' } as unknown as Location;
+
+const originalNavigatorShare = navigator.share;
+const originalNavigatorCanShare = (navigator as Navigator & { canShare?: (data: unknown) => boolean }).canShare;
+
+afterAll(() => {
+  window.location = originalLocation;
+  navigator.share = originalNavigatorShare;
+  (navigator as Navigator & { canShare?: (data: unknown) => boolean }).canShare =
+    originalNavigatorCanShare;
+});
+
+describe('sendBackupEmail', () => {
+  beforeEach(() => {
+    window.location.href = '';
+    navigator.share = undefined as unknown as typeof navigator.share;
+    (navigator as Navigator & { canShare?: (data: unknown) => boolean }).canShare =
+      undefined;
+  });
+
+  it('uses Web Share API when available', async () => {
+    const shareMock = jest.fn().mockResolvedValue(undefined);
+    navigator.share = shareMock;
+    (navigator as Navigator & { canShare?: (data: unknown) => boolean }).canShare =
+      jest.fn(() => true);
+
+    await sendBackupEmail('{"a":1}', 'test@example.com');
+
+    expect(shareMock).toHaveBeenCalled();
+    expect(window.location.href).toBe('');
+  });
+
+  it('falls back to mailto when share not supported', async () => {
+    await sendBackupEmail('{"a":1}', 'user@example.com');
+
+    expect(window.location.href).toContain('mailto:user%40example.com');
+    expect(window.location.href).not.toContain('base64');
+  });
+
+  it('falls back to mailto when share throws', async () => {
+    const shareMock = jest.fn().mockRejectedValue(new Error('fail'));
+    navigator.share = shareMock;
+    (navigator as Navigator & { canShare?: (data: unknown) => boolean }).canShare =
+      jest.fn(() => true);
+
+    await sendBackupEmail('{"a":1}', 'user2@example.com');
+
+    expect(shareMock).toHaveBeenCalled();
+    expect(window.location.href).toContain('mailto:user2%40example.com');
+  });
+});

--- a/src/utils/sendBackupEmail.ts
+++ b/src/utils/sendBackupEmail.ts
@@ -1,22 +1,29 @@
-import { Buffer } from 'buffer';
-
-const toBase64 = (data: string): string => {
-  if (typeof window === 'undefined') {
-    return Buffer.from(data, 'utf8').toString('base64');
-  }
-  return btoa(unescape(encodeURIComponent(data)));
-};
-
 export const sendBackupEmail = async (json: string, email: string): Promise<void> => {
   if (typeof window === 'undefined') {
     throw new Error('Email send not supported on server');
   }
+
   const filename = `SoccerApp_Backup_${new Date()
     .toISOString()
     .replace(/[:.]/g, '-')}.json`;
-  const base64 = toBase64(json);
+
+  const file = new File([json], filename, { type: 'application/json' });
+
+  if (navigator.canShare && navigator.canShare({ files: [file] })) {
+    try {
+      await navigator.share({
+        files: [file],
+        title: 'Soccer App Backup',
+        text: 'Backup file attached',
+      });
+      return;
+    } catch {
+      // fall through to mailto fallback
+    }
+  }
+
   const subject = encodeURIComponent(`Soccer App Backup - ${filename}`);
-  const body = encodeURIComponent(base64);
+  const body = encodeURIComponent('Backup file generated. Attach the downloaded file to this email.');
   const url = `mailto:${encodeURIComponent(email)}?subject=${subject}&body=${body}`;
   try {
     window.location.href = url;


### PR DESCRIPTION
## Summary
- rework `sendBackupEmail` to share files through the Web Share API when available
- fall back to a small mailto link when sharing isn't supported
- add unit tests for new behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68796d044a60832cb428bbfaca05d0f2