### PR TITLE
Update StartScreen layout

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -27,7 +27,7 @@ const StartScreen: React.FC<StartScreenProps> = ({
     'w-64 px-4 py-2 rounded-md text-lg font-semibold bg-indigo-600 hover:bg-indigo-700 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500';
 
   const containerStyle =
-    'relative flex flex-col items-center justify-center min-h-screen bg-slate-950 text-slate-100 font-display overflow-hidden';
+    'relative flex flex-col items-center justify-center min-h-screen bg-slate-950 text-slate-100 font-display overflow-hidden pt-12 pb-24';
 
   const taglineStyle =
     'text-xl text-slate-300 mb-10 text-center max-w-sm drop-shadow-lg italic';
@@ -59,7 +59,10 @@ const StartScreen: React.FC<StartScreenProps> = ({
           height={128}
           className="mb-4"
         />
-        <h1 className={titleStyle}>MatchDay Coach</h1>
+        <h1 className={titleStyle}>
+          <span className="block">MatchDay</span>
+          <span className="block">Coach</span>
+        </h1>
         <p className={taglineStyle}>{t('startScreen.tagline', 'Elevate Your Game')}</p>
         {canResume && onResumeGame ? (
           <button className={buttonStyle} onClick={onResumeGame}>


### PR DESCRIPTION
## Summary
- tweak spacing in StartScreen to improve vertical balance
- split title across two lines for better readability

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687aa458262c832cadf40fceaddf8c2e