### PR TITLE
Add email backup instructions

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -591,6 +591,7 @@
     "backupIntervalLabel": "Backup Interval (hours)",
     "backupEmailLabel": "Backup Email",
     "sendBackupButton": "Create & Send Backup",
+    "sendBackupDescription": "A backup file will download and your email app will open. Attach the file before sending.",
     "sendBackupSuccess": "Backup sent successfully.",
     "sendBackupError": "Failed to send backup.",
     "lastBackupLabel": "Last Backup",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -582,6 +582,7 @@
     "backupIntervalLabel": "Varmuuskopiointiväli (tuntia)",
     "backupEmailLabel": "Varmuuskopion sähköposti",
     "sendBackupButton": "Luo ja lähetä varmuuskopio",
+    "sendBackupDescription": "Lataa varmuuskopiotiedosto ja avaa sähköpostisovellus. Liitä tiedosto viestiin ennen lähettämistä.",
     "sendBackupSuccess": "Varmuuskopio lähetetty.",
     "sendBackupError": "Varmuuskopion lähetys epäonnistui.",
     "lastBackupLabel": "Viimeinen varmuuskopio",

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -163,6 +163,12 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                 {t('settingsModal.sendBackupButton', 'Create & Send Backup')}
               </button>
               <p className="text-sm text-slate-300">
+                {t(
+                  'settingsModal.sendBackupDescription',
+                  'A backup file will download and your email app will open. Attach the file before sending.'
+                )}
+              </p>
+              <p className="text-sm text-slate-300">
                 {t('settingsModal.lastBackupLabel', 'Last Backup')}: {lastBackupTime ? new Date(lastBackupTime).toLocaleString() : t('settingsModal.never', 'Never')}
               </p>
             </div>

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -499,6 +499,7 @@ export type TranslationKey =
   | 'settingsModal.resetGuideButton'
   | 'settingsModal.resetGuideDescription'
   | 'settingsModal.sendBackupButton'
+  | 'settingsModal.sendBackupDescription'
   | 'settingsModal.sendBackupError'
   | 'settingsModal.sendBackupSuccess'
   | 'settingsModal.storageUsageDetails'


### PR DESCRIPTION
## Summary
- clarify how email backup works in SettingsModal
- add translations for the new instructions
- regenerate i18n types

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687abeade300832cb2876eb95efb030a