### PR TITLE
Remove StartScreen logo

### DIFF
--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -27,7 +27,7 @@ const StartScreen: React.FC<StartScreenProps> = ({
     'w-64 px-4 py-2 rounded-md text-lg font-semibold bg-indigo-600 hover:bg-indigo-700 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500';
 
   const containerStyle =
-    'relative flex flex-col items-center justify-center min-h-screen bg-slate-950 text-slate-100 font-display overflow-hidden pt-12 pb-24';
+    'relative flex flex-col items-center justify-center min-h-screen bg-slate-950 text-slate-100 font-display overflow-hidden py-24';
 
   const taglineStyle =
     'text-xl text-slate-300 mb-6 text-center max-w-sm drop-shadow-lg italic';
@@ -52,13 +52,6 @@ const StartScreen: React.FC<StartScreenProps> = ({
       />
 
       <div className="relative z-10 flex flex-col items-center space-y-5">
-        <Image
-          src="/pepo-logo.png"
-          alt="MatchDay Coach Logo"
-          width={128}
-          height={128}
-          className="mb-4"
-        />
         <h1 className={titleStyle}>
           <span className="block">MatchDay</span>
           <span className="block">Coach</span>


### PR DESCRIPTION
## Summary
- remove the top logo from `StartScreen`
- rebalance padding so content stays centered

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ac0c805d0832ca73e07b104e92eda