### PR TITLE
Add language selection on start screen

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -464,6 +464,7 @@
     "startNewGame": "Start New Game",
     "loadGame": "Load Game",
     "resumeGame": "Resume Last Game",
+    "languageLabel": "Language",
     "createSeasonTournament": "Create Season/Tournament",
     "viewStats": "View Stats"
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -378,6 +378,7 @@
     "startNewGame": "Aloita uusi ottelu",
     "loadGame": "Lataa peli",
     "resumeGame": "Jatka edellistä peliä",
+    "languageLabel": "Kieli",
     "createSeasonTournament": "Luo kausi/turnaus",
     "viewStats": "Näytä tilastot"
   },

--- a/src/components/StartScreen.test.tsx
+++ b/src/components/StartScreen.test.tsx
@@ -3,6 +3,23 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import StartScreen from './StartScreen';
 
+jest.mock('@/i18n', () => ({
+  __esModule: true,
+  default: {
+    language: 'en',
+    changeLanguage: jest.fn(),
+    isInitialized: true,
+    on: jest.fn(),
+    off: jest.fn(),
+  },
+}));
+
+jest.mock('@/utils/appSettings', () => ({
+  __esModule: true,
+  getAppSettings: jest.fn().mockResolvedValue({ language: 'en' }),
+  updateAppSettings: jest.fn().mockResolvedValue({}),
+}));
+
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, fallback?: string) => fallback || key,
@@ -35,6 +52,7 @@ describe('StartScreen', () => {
     expect(screen.getByRole('button', { name: 'Load Game' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Season/Tournament' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'View Stats' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Language')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Start New Game' }));
     expect(handlers.onStartNewGame).toHaveBeenCalled();

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useTranslation } from 'react-i18next';
+import i18n from '@/i18n';
+import { updateAppSettings, getAppSettings } from '@/utils/appSettings';
 
 interface StartScreenProps {
   onStartNewGame: () => void;
@@ -22,6 +24,20 @@ const StartScreen: React.FC<StartScreenProps> = ({
   canResume = false,
 }) => {
   const { t } = useTranslation();
+  const [language, setLanguage] = useState<string>(i18n.language);
+
+  useEffect(() => {
+    getAppSettings().then((settings) => {
+      if (settings.language) {
+        setLanguage(settings.language);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    i18n.changeLanguage(language);
+    updateAppSettings({ language }).catch(() => {});
+  }, [language]);
 
   const buttonStyle =
     'w-64 px-4 py-2 rounded-md text-lg font-semibold bg-indigo-600 hover:bg-indigo-700 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500';
@@ -57,6 +73,20 @@ const StartScreen: React.FC<StartScreenProps> = ({
           <span className="block">Coach</span>
         </h1>
         <p className={taglineStyle}>{t('startScreen.tagline', 'Elevate Your Game')}</p>
+        <div className="flex flex-col items-center">
+          <label htmlFor="start-language-select" className="text-sm font-medium text-slate-300 mb-1">
+            {t('startScreen.languageLabel', 'Language')}
+          </label>
+          <select
+            id="start-language-select"
+            value={language}
+            onChange={(e) => setLanguage(e.target.value)}
+            className="px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          >
+            <option value="en">English</option>
+            <option value="fi">Suomi</option>
+          </select>
+        </div>
         {canResume && onResumeGame ? (
           <button className={buttonStyle} onClick={onResumeGame}>
             {t('startScreen.resumeGame', 'Resume Last Game')}

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -507,6 +507,7 @@ export type TranslationKey =
   | 'settingsModal.storageUsageUnavailable'
   | 'settingsModal.title'
   | 'startScreen.createSeasonTournament'
+  | 'startScreen.languageLabel'
   | 'startScreen.loadGame'
   | 'startScreen.resumeGame'
   | 'startScreen.startNewGame'


### PR DESCRIPTION
## Summary
- allow language choice on the initial start screen
- add English and Finnish labels for the new selector
- update tests and i18n type definitions

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac450fa20832c962528b6d7d091b3