### PR TITLE
Add flag-based language picker

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -465,6 +465,8 @@
     "loadGame": "Load Game",
     "resumeGame": "Resume Last Game",
     "languageLabel": "Language",
+    "languageEnglish": "English",
+    "languageFinnish": "Finnish",
     "createSeasonTournament": "Create Season/Tournament",
     "viewStats": "View Stats"
   },

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -379,6 +379,8 @@
     "loadGame": "Lataa peli",
     "resumeGame": "Jatka edellistä peliä",
     "languageLabel": "Kieli",
+    "languageEnglish": "Englanti",
+    "languageFinnish": "Suomi",
     "createSeasonTournament": "Luo kausi/turnaus",
     "viewStats": "Näytä tilastot"
   },

--- a/src/components/StartScreen.test.tsx
+++ b/src/components/StartScreen.test.tsx
@@ -52,12 +52,16 @@ describe('StartScreen', () => {
     expect(screen.getByRole('button', { name: 'Load Game' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create Season/Tournament' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'View Stats' })).toBeInTheDocument();
-    expect(screen.getByLabelText('Language')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'English' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Finnish' })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Start New Game' }));
     expect(handlers.onStartNewGame).toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Resume Last Game' }));
     expect(handlers.onResumeGame).toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Finnish' }));
+    expect(require('@/i18n').default.changeLanguage).toHaveBeenCalledWith('fi');
   });
 });

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -74,18 +74,29 @@ const StartScreen: React.FC<StartScreenProps> = ({
         </h1>
         <p className={taglineStyle}>{t('startScreen.tagline', 'Elevate Your Game')}</p>
         <div className="flex flex-col items-center">
-          <label htmlFor="start-language-select" className="text-sm font-medium text-slate-300 mb-1">
+          <span className="text-sm font-medium text-slate-300 mb-1">
             {t('startScreen.languageLabel', 'Language')}
-          </label>
-          <select
-            id="start-language-select"
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
-            className="px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white focus:outline-none focus:ring-1 focus:ring-indigo-500"
-          >
-            <option value="en">English</option>
-            <option value="fi">Suomi</option>
-          </select>
+          </span>
+          <div className="flex space-x-2">
+            <button
+              aria-label={t('startScreen.languageEnglish', 'English')}
+              onClick={() => setLanguage('en')}
+              className={`w-10 h-8 rounded-md border text-xl flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 ${language === 'en' ? 'bg-indigo-600 border-indigo-500 text-white' : 'bg-slate-700 border-slate-600 text-white hover:bg-slate-600'}`}
+            >
+              <span role="img" aria-hidden="true">
+                🇬🇧
+              </span>
+            </button>
+            <button
+              aria-label={t('startScreen.languageFinnish', 'Finnish')}
+              onClick={() => setLanguage('fi')}
+              className={`w-10 h-8 rounded-md border text-xl flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 ${language === 'fi' ? 'bg-indigo-600 border-indigo-500 text-white' : 'bg-slate-700 border-slate-600 text-white hover:bg-slate-600'}`}
+            >
+              <span role="img" aria-hidden="true">
+                🇫🇮
+              </span>
+            </button>
+          </div>
         </div>
         {canResume && onResumeGame ? (
           <button className={buttonStyle} onClick={onResumeGame}>

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -507,6 +507,8 @@ export type TranslationKey =
   | 'settingsModal.storageUsageUnavailable'
   | 'settingsModal.title'
   | 'startScreen.createSeasonTournament'
+  | 'startScreen.languageEnglish'
+  | 'startScreen.languageFinnish'
   | 'startScreen.languageLabel'
   | 'startScreen.loadGame'
   | 'startScreen.resumeGame'


### PR DESCRIPTION
## Summary
- replace dropdown with flag buttons for language selection on StartScreen
- update translations for new button labels
- test StartScreen language buttons

## Testing
- `npm run generate:i18n-types`
- `npx next lint` *(fails: Need to install next)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac8bd3430832cba64042dd6a47857