### PR TITLE
Extend AppState with isPlayed field

### DIFF
--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -74,6 +74,8 @@ export interface AppState {
   tacticalDiscs: TacticalDisc[];
   tacticalDrawings: Point[][];
   tacticalBallPosition: Point | null;
+  /** Whether the game has been played. Defaults to true for existing games */
+  isPlayed?: boolean;
 }
 
 export interface SavedGamesCollection {

--- a/src/utils/appStateSchema.ts
+++ b/src/utils/appStateSchema.ts
@@ -98,6 +98,7 @@ export const appStateSchema = z.object({
   tacticalDiscs: z.array(tacticalDiscSchema),
   tacticalDrawings: z.array(z.array(pointSchema)),
   tacticalBallPosition: pointSchema.nullable(),
+  isPlayed: z.boolean().optional(),
 });
 
 export type AppStateSchema = typeof appStateSchema;

--- a/src/utils/assessmentStats.ts
+++ b/src/utils/assessmentStats.ts
@@ -37,6 +37,7 @@ export function getPlayerAssessmentTrends(playerId: string, games: SavedGamesCol
   const trends: { [metric: string]: MetricTrendPoint[] } = {};
   METRICS.forEach(m => { trends[m] = []; });
   for (const game of Object.values(games)) {
+    if (game.isPlayed === false) continue;
     const a = game.assessments?.[playerId];
     if (!a) continue;
     METRICS.forEach(m => {
@@ -50,6 +51,7 @@ export function getPlayerAssessmentTrends(playerId: string, games: SavedGamesCol
 export function getPlayerAssessmentNotes(playerId: string, games: SavedGamesCollection): { date: string; notes: string }[] {
   const notes: { date: string; notes: string }[] = [];
   for (const game of Object.values(games)) {
+    if (game.isPlayed === false) continue;
     const a = game.assessments?.[playerId];
     if (a && a.notes) notes.push({ date: game.gameDate, notes: a.notes });
   }
@@ -69,6 +71,7 @@ export function calculatePlayerAssessmentAverages(
   let finalScoreTotal = 0;
   let denominator = 0;
   for (const game of Object.values(games)) {
+    if (game.isPlayed === false) continue;
     const a = game.assessments?.[playerId];
     if (!a) continue;
     count++;
@@ -100,6 +103,7 @@ export function calculateTeamAssessmentAverages(
   let finalScoreTotal = 0;
   let denominator = 0;
   for (const game of Object.values(games)) {
+    if (game.isPlayed === false) continue;
     if (!game.assessments) continue;
     const players = Object.values(game.assessments);
     if (players.length === 0) continue;

--- a/src/utils/migrateSavedGames.test.ts
+++ b/src/utils/migrateSavedGames.test.ts
@@ -1,0 +1,72 @@
+import { migrateSavedGamesIsPlayed } from './migrateSavedGames';
+import { getSavedGames, saveGames } from './savedGames';
+import type { SavedGamesCollection, AppState } from '@/types';
+
+jest.mock('./savedGames');
+const mockedGetSavedGames = getSavedGames as jest.MockedFunction<typeof getSavedGames>;
+const mockedSaveGames = saveGames as jest.MockedFunction<typeof saveGames>;
+
+const baseGame: AppState = {
+  playersOnField: [],
+  opponents: [],
+  drawings: [],
+  availablePlayers: [],
+  showPlayerNames: true,
+  teamName: 'Team',
+  gameEvents: [],
+  opponentName: 'Opp',
+  gameDate: '2025-01-01',
+  homeScore: 0,
+  awayScore: 0,
+  gameNotes: '',
+  homeOrAway: 'home',
+  numberOfPeriods: 2,
+  periodDurationMinutes: 10,
+  currentPeriod: 1,
+  gameStatus: 'notStarted',
+  selectedPlayerIds: [],
+  assessments: {},
+  seasonId: '',
+  tournamentId: '',
+  gameLocation: '',
+  gameTime: '',
+  subIntervalMinutes: 5,
+  completedIntervalDurations: [],
+  lastSubConfirmationTimeSeconds: 0,
+  tacticalDiscs: [],
+  tacticalDrawings: [],
+  tacticalBallPosition: { relX: 0, relY: 0 },
+};
+
+describe('migrateSavedGamesIsPlayed', () => {
+  beforeEach(() => {
+    mockedGetSavedGames.mockReset();
+    mockedSaveGames.mockReset();
+  });
+
+  it('adds isPlayed true to games missing the field', async () => {
+    const games: SavedGamesCollection = {
+      g1: { ...baseGame },
+      g2: { ...baseGame, isPlayed: false },
+    };
+    mockedGetSavedGames.mockResolvedValue(games);
+    mockedSaveGames.mockResolvedValue();
+
+    const updated = await migrateSavedGamesIsPlayed();
+    expect(updated).toBe(1);
+    expect(games.g1.isPlayed).toBe(true);
+    expect(games.g2.isPlayed).toBe(false);
+    expect(mockedSaveGames).toHaveBeenCalledWith(games);
+  });
+
+  it('does nothing when all games have the field', async () => {
+    const games: SavedGamesCollection = {
+      g1: { ...baseGame, isPlayed: true },
+    };
+    mockedGetSavedGames.mockResolvedValue(games);
+
+    const updated = await migrateSavedGamesIsPlayed();
+    expect(updated).toBe(0);
+    expect(mockedSaveGames).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/migrateSavedGames.ts
+++ b/src/utils/migrateSavedGames.ts
@@ -1,0 +1,27 @@
+import { getSavedGames, saveGames } from './savedGames';
+import type { SavedGamesCollection } from '@/types';
+import logger from './logger';
+
+/**
+ * Adds `isPlayed: true` to any saved game lacking the property.
+ * @returns number of games updated
+ */
+export const migrateSavedGamesIsPlayed = async (): Promise<number> => {
+  try {
+    const games = await getSavedGames();
+    let updated = 0;
+    Object.values(games).forEach((game) => {
+      if (game.isPlayed === undefined) {
+        game.isPlayed = true;
+        updated++;
+      }
+    });
+    if (updated > 0) {
+      await saveGames(games as SavedGamesCollection);
+    }
+    return updated;
+  } catch (error) {
+    logger.error('Error migrating saved games:', error);
+    throw error;
+  }
+};

--- a/src/utils/playerStats.ts
+++ b/src/utils/playerStats.ts
@@ -37,6 +37,9 @@ export const calculatePlayerStats = (player: Player, savedGames: { [key: string]
   const performanceByTournament: { [tournamentId: string]: { name: string, gamesPlayed: number, goals: number, assists: number, points: number } } = {};
 
   Object.entries(savedGames).forEach(([gameId, game]) => {
+    if (game.isPlayed === false) {
+      return;
+    }
     // Check if the player was part of this game's roster
     if (game.selectedPlayerIds?.includes(player.id)) {
       const goals = game.gameEvents?.filter(e => e.type === 'goal' && e.scorerId === player.id).length || 0;

--- a/src/utils/savedGames.test.ts
+++ b/src/utils/savedGames.test.ts
@@ -305,6 +305,7 @@ describe('Saved Games Utilities', () => {
       // Check some default fields from AppState that createGame sets
       expect(result.gameData.opponentName).toBe('Opponent'); // Default from createGame via AppState structure
       expect(result.gameData.gameStatus).toBe('notStarted');
+      expect(result.gameData.isPlayed).toBe(true);
 
       // Verify it was saved to localStorage
       expect(localStorageMock.setItem).toHaveBeenCalledTimes(1);
@@ -326,6 +327,7 @@ describe('Saved Games Utilities', () => {
       expect(result.gameData.numberOfPeriods).toBe(2);
       expect(result.gameData.periodDurationMinutes).toBe(10);
       expect(result.gameData.subIntervalMinutes).toBe(5);
+      expect(result.gameData.isPlayed).toBe(true);
     });
 
     it('should reject if internal saveGame fails', async () => {

--- a/src/utils/savedGames.ts
+++ b/src/utils/savedGames.ts
@@ -170,6 +170,7 @@ export const createGame = async (gameData: Partial<AppState>): Promise<{ gameId:
       periodDurationMinutes: gameData.periodDurationMinutes || 10,
       currentPeriod: gameData.currentPeriod || 1,
       gameStatus: gameData.gameStatus || 'notStarted',
+      isPlayed: gameData.isPlayed === undefined ? true : gameData.isPlayed,
       selectedPlayerIds: gameData.selectedPlayerIds || [],
       assessments: gameData.assessments || {},
       seasonId: gameData.seasonId || '',


### PR DESCRIPTION
## Summary
- add optional `isPlayed` flag to `AppState`
- validate `isPlayed` in `appStateSchema`
- set `isPlayed` default when creating a game
- ignore unplayed games in statistics helpers
- add migration util to update saved games
- update tests for the new flag

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d06e79894832cbab6a2d95668d3e3