### PR TITLE
Fix not played checkbox persistence

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -981,6 +981,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
           awayScore: gameSessionState.awayScore,
           gameNotes: gameSessionState.gameNotes,
           homeOrAway: gameSessionState.homeOrAway,
+          isPlayed,
           numberOfPeriods: gameSessionState.numberOfPeriods,
           periodDurationMinutes: gameSessionState.periodDurationMinutes,
           currentPeriod: gameSessionState.currentPeriod, // Persisted
@@ -1037,6 +1038,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
       tacticalDiscs,
       tacticalDrawings,
       tacticalBallPosition,
+      isPlayed,
     ]);
 
   // **** ADDED: Effect to prompt for setup if default game ID is loaded ****
@@ -1909,6 +1911,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
           completedIntervalDurations: gameSessionState.completedIntervalDurations,
           lastSubConfirmationTimeSeconds: gameSessionState.lastSubConfirmationTimeSeconds,
           homeOrAway: gameSessionState.homeOrAway,
+          isPlayed,
         };
 
         const { gameId, gameData } = await createGame(newSnapshot);
@@ -1936,7 +1939,8 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
     resetHistory,
     showToast,
     gameSessionState, // This now covers all migrated game session fields
-    playerAssessments
+    playerAssessments,
+    isPlayed
   ]);
   // --- END Quick Save Handler ---
 


### PR DESCRIPTION
## Summary
- ensure isPlayed state persists by including it in quick save and autosave snapshots
- update dependency arrays after using isPlayed in effects

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e48acf35c832cbc9f659ca97258f0