### PR TITLE
Add toast variants and dismissible update banner

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -656,7 +656,8 @@
   },
   "updateBanner": {
     "message": "A new version of the app is available.",
-    "reloadButton": "Reload"
+    "reloadButton": "Reload",
+    "dismissButton": "Dismiss"
   },
   "installPrompt": {
     "message": "Install Coaching Companion for a faster, offline experience!",

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -647,7 +647,8 @@
   },
   "updateBanner": {
     "message": "Sovelluksesta on saatavilla uusi versio.",
-    "reloadButton": "Päivitä"
+    "reloadButton": "Päivitä",
+    "dismissButton": "Sulje"
   },
   "installPrompt": {
     "message": "Asenna Coaching Companion saadaksesi nopeamman ja offline-toimivan kokemuksen!",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,6 +119,28 @@ body > div {
   border-radius: 0.375rem;
 }
 
+@keyframes fade-in-out {
+  0% {
+    opacity: 0;
+    transform: translateY(-0.5rem);
+  }
+  10% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  90% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-0.5rem);
+  }
+}
+
+.animate-fade-in-out {
+  animation: fade-in-out 3s ease-in-out forwards;
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -78,5 +78,11 @@ export default function ServiceWorkerRegistration() {
     }
   };
 
-  return showUpdateBanner ? <UpdateBanner onUpdate={handleUpdate} notes={releaseNotes || undefined} /> : null;
+  return showUpdateBanner ? (
+    <UpdateBanner
+      onUpdate={handleUpdate}
+      notes={releaseNotes || undefined}
+      onDismiss={() => setShowUpdateBanner(false)}
+    />
+  ) : null;
 }

--- a/src/components/UpdateBanner.test.tsx
+++ b/src/components/UpdateBanner.test.tsx
@@ -13,4 +13,11 @@ describe('UpdateBanner', () => {
     render(<UpdateBanner onUpdate={() => {}} />);
     expect(screen.queryByText('Some fixes')).not.toBeInTheDocument();
   });
+
+  it('hides banner when dismissed', () => {
+    render(<UpdateBanner onUpdate={() => {}} />);
+    const button = screen.getByRole('button', { name: /dismiss/i });
+    button.click();
+    expect(screen.queryByText(/new version/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/components/UpdateBanner.tsx
+++ b/src/components/UpdateBanner.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import React from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { HiOutlineXMark } from "react-icons/hi2";
 
 interface UpdateBannerProps {
   onUpdate: () => void;
   notes?: string;
+  onDismiss?: () => void;
 }
 
-const UpdateBanner: React.FC<UpdateBannerProps> = ({ onUpdate, notes }) => {
+const UpdateBanner: React.FC<UpdateBannerProps> = ({ onUpdate, notes, onDismiss }) => {
   const { t } = useTranslation();
+  const [hidden, setHidden] = useState(false);
+
+  if (hidden) return null;
+
+  const handleDismiss = () => {
+    setHidden(true);
+    onDismiss?.();
+  };
+
   return (
     <div className="fixed bottom-4 left-1/2 -translate-x-1/2 bg-slate-800 text-white p-4 rounded-lg shadow-lg border border-slate-700 flex flex-col sm:flex-row items-center gap-2 sm:gap-4 z-50">
       <p className="text-sm">{t("updateBanner.message")}</p>
@@ -19,6 +30,13 @@ const UpdateBanner: React.FC<UpdateBannerProps> = ({ onUpdate, notes }) => {
         className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white font-semibold rounded-md text-sm transition-colors"
       >
         {t("updateBanner.reloadButton")}
+      </button>
+      <button
+        onClick={handleDismiss}
+        className="text-slate-400 hover:text-slate-200"
+        aria-label={t("updateBanner.dismissButton")}
+      >
+        <HiOutlineXMark className="w-5 h-5" />
       </button>
     </div>
   );

--- a/src/contexts/ToastProvider.tsx
+++ b/src/contexts/ToastProvider.tsx
@@ -3,10 +3,11 @@ import React, { createContext, useContext, useState } from 'react';
 interface Toast {
   id: number;
   message: string;
+  type: 'success' | 'error' | 'info';
 }
 
 interface ToastContextValue {
-  showToast: (message: string) => void;
+  showToast: (message: string, type?: Toast['type']) => void;
 }
 
 const ToastContext = createContext<ToastContextValue | undefined>(undefined);
@@ -14,11 +15,11 @@ const ToastContext = createContext<ToastContextValue | undefined>(undefined);
 export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const showToast = (message: string) => {
+  const showToast = (message: string, type: Toast['type'] = 'success') => {
     const id = Date.now();
-    setToasts((prev) => [...prev, { id, message }]);
+    setToasts(prev => [...prev, { id, message, type }]);
     setTimeout(() => {
-      setToasts((prev) => prev.filter((t) => t.id !== id));
+      setToasts(prev => prev.filter(t => t.id !== id));
     }, 3000);
   };
 
@@ -26,14 +27,18 @@ export const ToastProvider = ({ children }: { children: React.ReactNode }) => {
     <ToastContext.Provider value={{ showToast }}>
       {children}
       <div className="fixed top-4 right-4 space-y-2 z-50">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            className="bg-green-600 text-white px-4 py-2 rounded shadow"
-          >
-            {t.message}
-          </div>
-        ))}
+        {toasts.map(t => {
+          const base = 'text-white px-4 py-2 rounded shadow animate-fade-in-out';
+          const color =
+            t.type === 'error'
+              ? 'bg-red-600'
+              : t.type === 'info'
+                ? 'bg-slate-600'
+                : 'bg-green-600';
+          return (
+            <div key={t.id} className={`${base} ${color}`}>{t.message}</div>
+          );
+        })}
       </div>
     </ToastContext.Provider>
   );

--- a/src/contexts/__tests__/ToastProvider.test.tsx
+++ b/src/contexts/__tests__/ToastProvider.test.tsx
@@ -4,7 +4,12 @@ import { ToastProvider, useToast } from '../ToastProvider';
 
 const TestComponent = () => {
   const { showToast } = useToast();
-  return <button onClick={() => showToast('Saved!')}>Trigger</button>;
+  return (
+    <>
+      <button onClick={() => showToast('Saved!', 'success')}>Success</button>
+      <button onClick={() => showToast('Error!', 'error')}>Error</button>
+    </>
+  );
 };
 
 test('showToast displays and hides a toast message', () => {
@@ -15,12 +20,16 @@ test('showToast displays and hides a toast message', () => {
     </ToastProvider>
   );
 
-  fireEvent.click(screen.getByText('Trigger'));
-  expect(screen.getByText('Saved!')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Success'));
+  expect(screen.getByText('Saved!')).toHaveClass('bg-green-600');
+
+  fireEvent.click(screen.getByText('Error'));
+  expect(screen.getByText('Error!')).toHaveClass('bg-red-600');
 
   act(() => {
     jest.advanceTimersByTime(3000);
   });
 
   expect(screen.queryByText('Saved!')).not.toBeInTheDocument();
+  expect(screen.queryByText('Error!')).not.toBeInTheDocument();
 });

--- a/src/i18n-types.ts
+++ b/src/i18n-types.ts
@@ -554,6 +554,7 @@ export type TranslationKey =
   | 'trainingResourcesModal.navExampleDrills'
   | 'trainingResourcesModal.navWarmup'
   | 'trainingResourcesModal.title'
+  | 'updateBanner.dismissButton'
   | 'updateBanner.message'
   | 'updateBanner.reloadButton'
   | 'warmup.duringGamePoints'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,5 +20,6 @@ module.exports = {
   plugins: [],
   safelist: [
     'animate-pulse',
+    'animate-fade-in-out',
   ],
-} 
+}


### PR DESCRIPTION
## Summary
- support success/error/info types in ToastProvider with fade animation
- add dismiss button for UpdateBanner and wire up ServiceWorkerRegistration
- add fade-in-out animation
- update translations and generated i18n types
- test toast variants and banner dismissal

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687eb40fe938832c9d37a7c4cc1564be