### PR TITLE
Refactor large modal forms

### DIFF
--- a/src/components/GameSettingsModal.tsx
+++ b/src/components/GameSettingsModal.tsx
@@ -13,6 +13,8 @@ import { updateGameDetails, updateGameEvent, removeGameEvent } from '@/utils/sav
 import { UseMutationResult } from '@tanstack/react-query';
 import { TFunction } from 'i18next';
 import AssessmentSlider from './AssessmentSlider';
+import PlayerSelectionSection from './PlayerSelectionSection';
+import TeamOpponentInputs from './TeamOpponentInputs';
 import { AGE_GROUPS, LEVELS } from '@/config/gameOptions';
 import type { TranslationKey } from '@/i18n-types';
 
@@ -837,35 +839,16 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
 
           {/* Fixed Controls Section */}
           <div className="px-6 pt-3 pb-4 backdrop-blur-sm bg-slate-900/20">
-            {/* Team Name */}
-            <div className="mb-4">
-              <label htmlFor="teamNameInput" className="block text-sm font-medium text-slate-300 mb-1">
-                {t('gameSettingsModal.teamName', 'Your Team Name')} *
-              </label>
-              <input
-                type="text"
-                id="teamNameInput"
-                value={teamName}
-                onChange={(e) => onTeamNameChange(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
-                placeholder={t('gameSettingsModal.teamNamePlaceholder', 'Enter team name')}
-              />
-            </div>
-
-            {/* Opponent Name */}
-            <div className="mb-4">
-              <label htmlFor="opponentNameInput" className="block text-sm font-medium text-slate-300 mb-1">
-                {t('gameSettingsModal.opponentName', 'Opponent Name')} *
-              </label>
-              <input
-                type="text"
-                id="opponentNameInput"
-                value={opponentName}
-                onChange={(e) => onOpponentNameChange(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
-                placeholder={t('gameSettingsModal.opponentNamePlaceholder', 'Enter opponent name')}
-              />
-            </div>
+            <TeamOpponentInputs
+              teamName={teamName}
+              opponentName={opponentName}
+              onTeamNameChange={onTeamNameChange}
+              onOpponentNameChange={onOpponentNameChange}
+              teamLabel={t('gameSettingsModal.teamName', 'Your Team Name') + ' *'}
+              teamPlaceholder={t('gameSettingsModal.teamNamePlaceholder', 'Enter team name')}
+              opponentLabel={t('gameSettingsModal.opponentName', 'Opponent Name') + ' *'}
+              opponentPlaceholder={t('gameSettingsModal.opponentNamePlaceholder', 'Enter opponent name')}
+            />
           </div>
 
           {/* Scrollable Content Area */}
@@ -1298,77 +1281,16 @@ const GameSettingsModal: React.FC<GameSettingsModalProps> = ({
                 </div>
 
                 {/* Player Selection Section */}
-                <div className="space-y-4 bg-slate-900/70 p-4 rounded-lg border border-slate-700 shadow-inner">
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-lg font-semibold text-slate-200">
-                      {t('gameSettingsModal.selectPlayers', 'Select Players')}
-                    </h3>
-                    <div className="text-sm text-slate-400">
-                      <span className="text-yellow-400 font-semibold">{selectedPlayerIds.length}</span>
-                      {" / "}
-                      <span className="text-yellow-400 font-semibold">{availablePlayers.length}</span>
-                      {" "}{t('gameSettingsModal.playersSelected', 'selected')}
-                    </div>
-                  </div>
-
-                  {availablePlayers.length > 0 ? (
-                    <>
-                      {/* Select All Header */}
-                      <div className="flex items-center py-2 px-1 border-b border-slate-700/50">
-                        <label className="flex items-center text-sm text-slate-300 hover:text-slate-200 cursor-pointer">
-                          <input
-                            type="checkbox"
-                            checked={availablePlayers.length === selectedPlayerIds.length}
-                            onChange={() => {
-                              if (selectedPlayerIds.length === availablePlayers.length) {
-                                onSelectedPlayersChange([]);
-                              } else {
-                                onSelectedPlayersChange(availablePlayers.map(p => p.id));
-                              }
-                            }}
-                            className="form-checkbox h-4 w-4 text-indigo-600 bg-slate-700 border-slate-500 rounded focus:ring-indigo-500 focus:ring-offset-slate-800"
-                          />
-                          <span className="ml-2">{t('gameSettingsModal.selectAll', 'Select All')}</span>
-                        </label>
-                      </div>
-
-                      {/* Player List */}
-                      <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
-                        {availablePlayers.map((player) => (
-                          <div
-                            key={player.id}
-                            className="flex items-center py-1.5 px-1 rounded hover:bg-slate-800/40 transition-colors"
-                          >
-                            <label className="flex items-center flex-1 cursor-pointer">
-                              <input
-                                type="checkbox"
-                                checked={selectedPlayerIds.includes(player.id)}
-                                onChange={() => {
-                                  if (selectedPlayerIds.includes(player.id)) {
-                                    onSelectedPlayersChange(selectedPlayerIds.filter(id => id !== player.id));
-                                  } else {
-                                    onSelectedPlayersChange([...selectedPlayerIds, player.id]);
-                                  }
-                                }}
-                                className="form-checkbox h-4 w-4 text-indigo-600 bg-slate-700 border-slate-500 rounded focus:ring-indigo-500 focus:ring-offset-slate-800"
-                              />
-                              <span className="ml-2 text-slate-200">
-                                {player.name}
-                                {player.nickname && (
-                                  <span className="text-slate-400 ml-1">({player.nickname})</span>
-                                )}
-                              </span>
-                            </label>
-                          </div>
-                        ))}
-                      </div>
-                    </>
-                  ) : (
-                    <div className="text-center py-4 text-slate-400">
-                      {t('gameSettingsModal.noPlayersInRoster', 'No players in roster. Add players in Roster Settings.')}
-                    </div>
-                  )}
-                </div>
+                <PlayerSelectionSection
+                  availablePlayers={availablePlayers}
+                  selectedPlayerIds={selectedPlayerIds}
+                  onSelectedPlayersChange={onSelectedPlayersChange}
+                  title={t('gameSettingsModal.selectPlayers', 'Select Players')}
+                  playersSelectedText={t('gameSettingsModal.playersSelected', 'selected')}
+                  selectAllText={t('gameSettingsModal.selectAll', 'Select All')}
+                  noPlayersText={t('gameSettingsModal.noPlayersInRoster', 'No players in roster. Add players in Roster Settings.')}
+                  disabled={isProcessing}
+                />
               </div>
             </div>
 

--- a/src/components/NewGameSetupModal.tsx
+++ b/src/components/NewGameSetupModal.tsx
@@ -11,6 +11,8 @@ import { getMasterRoster } from '@/utils/masterRosterManager';
 import { getLastHomeTeamName as utilGetLastHomeTeamName, saveLastHomeTeamName as utilSaveLastHomeTeamName } from '@/utils/appSettings';
 import { UseMutationResult } from '@tanstack/react-query';
 import AssessmentSlider from './AssessmentSlider';
+import PlayerSelectionSection from './PlayerSelectionSection';
+import TeamOpponentInputs from './TeamOpponentInputs';
 import { AGE_GROUPS, LEVELS } from '@/config/gameOptions';
 import type { TranslationKey } from '@/i18n-types';
 
@@ -161,15 +163,6 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
     }
   }, [isOpen, initialPlayerSelection, t]);
 
-  // ADD Handler for toggling player selection
-  const handlePlayerSelectionToggle = (playerId: string) => {
-    setSelectedPlayerIds(prevSelectedIds => {
-      if (prevSelectedIds.includes(playerId)) {
-        return prevSelectedIds.filter(id => id !== playerId);
-    }
-      return [...prevSelectedIds, playerId];
-    });
-  };
 
   const handleSeasonChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
@@ -484,42 +477,20 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
 
           {/* Fixed Controls Section */}
           <div className="px-6 pt-3 pb-4 backdrop-blur-sm bg-slate-900/20">
-            {/* Home Team Name - Critical input that should always be visible */}
-            <div className="mb-4">
-              <label htmlFor="homeTeamName" className="block text-sm font-medium text-slate-300 mb-1">
-                {t('newGameSetupModal.homeTeamName', 'Your Team Name')} *
-              </label>
-              <input
-                type="text"
-                id="homeTeamName"
-                ref={homeTeamInputRef}
-                value={homeTeamName}
-                onChange={(e) => setHomeTeamName(e.target.value)}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
-                placeholder={t('newGameSetupModal.homeTeamPlaceholder', 'e.g., Galaxy U10')}
-                onKeyDown={handleKeyDown}
-                    disabled={isLoading}
-                  />
-                </div>
-
-
-            {/* Opponent Name - Also critical */}
-            <div className="mb-4">
-              <label htmlFor="opponentNameInput" className="block text-sm font-medium text-slate-300 mb-1">
-                {t('newGameSetupModal.opponentNameLabel', 'Opponent Name')} *
-              </label>
-              <input
-                ref={opponentInputRef}
-                type="text"
-                id="opponentNameInput"
-                value={opponentName}
-                onChange={(e) => setOpponentName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={t('newGameSetupModal.opponentPlaceholder', 'Enter opponent name')}
-                className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
-                disabled={isLoading}
-              />
-            </div>
+            <TeamOpponentInputs
+              teamName={homeTeamName}
+              opponentName={opponentName}
+              onTeamNameChange={setHomeTeamName}
+              onOpponentNameChange={setOpponentName}
+              teamLabel={t('newGameSetupModal.homeTeamName', 'Your Team Name') + ' *'}
+              teamPlaceholder={t('newGameSetupModal.homeTeamPlaceholder', 'e.g., Galaxy U10')}
+              opponentLabel={t('newGameSetupModal.opponentNameLabel', 'Opponent Name') + ' *'}
+              opponentPlaceholder={t('newGameSetupModal.opponentPlaceholder', 'Enter opponent name')}
+              teamInputRef={homeTeamInputRef}
+              opponentInputRef={opponentInputRef}
+              onKeyDown={handleKeyDown}
+              disabled={isLoading}
+            />
           </div>
 
           {/* Scrollable Content Area */}
@@ -776,71 +747,16 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
 
 
                     {/* Player Selection Section */}
-                    <div className="space-y-4 bg-slate-900/70 p-4 rounded-lg border border-slate-700 shadow-inner">
-                      <div className="flex items-center justify-between">
-                        <h3 className="text-lg font-semibold text-slate-200">
-                          {t('newGameSetupModal.selectPlayers', 'Select Players')}
-                        </h3>
-                        <div className="text-sm text-slate-400">
-                          <span className="text-yellow-400 font-semibold">{selectedPlayerIds.length}</span>
-                          {" / "}
-                          <span className="text-yellow-400 font-semibold">{availablePlayersForSetup.length}</span>
-                          {" "}{t('newGameSetupModal.playersSelected', 'selected')}
-                        </div>
-                      </div>
-
-                      {availablePlayersForSetup.length > 0 ? (
-                        <>
-                          {/* Select All Header */}
-                          <div className="flex items-center py-2 px-1 border-b border-slate-700/50">
-                            <label className="flex items-center text-sm text-slate-300 hover:text-slate-200 cursor-pointer">
-                              <input
-                                type="checkbox"
-                                checked={availablePlayersForSetup.length === selectedPlayerIds.length}
-                                onChange={() => {
-                                  if (selectedPlayerIds.length === availablePlayersForSetup.length) {
-                                    setSelectedPlayerIds([]);
-                                  } else {
-                                    setSelectedPlayerIds(availablePlayersForSetup.map(p => p.id));
-                                  }
-                                }}
-                                className="form-checkbox h-4 w-4 text-indigo-600 bg-slate-700 border-slate-500 rounded focus:ring-indigo-500 focus:ring-offset-slate-800"
-                              />
-                              <span className="ml-2">{t('newGameSetupModal.selectAll', 'Select All')}</span>
-                            </label>
-                          </div>
-
-                          {/* Player List */}
-                          <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
-                            {availablePlayersForSetup.map((player) => (
-                              <div
-                                key={player.id}
-                                className="flex items-center py-1.5 px-1 rounded hover:bg-slate-800/40 transition-colors"
-                              >
-                                <label className="flex items-center flex-1 cursor-pointer">
-                                  <input
-                                    type="checkbox"
-                                    checked={selectedPlayerIds.includes(player.id)}
-                                    onChange={() => handlePlayerSelectionToggle(player.id)}
-                                    className="form-checkbox h-4 w-4 text-indigo-600 bg-slate-700 border-slate-500 rounded focus:ring-indigo-500 focus:ring-offset-slate-800"
-                                  />
-                                  <span className="ml-2 text-slate-200">
-                                    {player.name}
-                                    {player.nickname && (
-                                      <span className="text-slate-400 ml-1">({player.nickname})</span>
-                                    )}
-                                  </span>
-                                </label>
-                              </div>
-                            ))}
-                          </div>
-                        </>
-                      ) : (
-                        <div className="text-center py-4 text-slate-400">
-                          {t('newGameSetupModal.noPlayersInRoster', 'No players in roster. Add players in Roster Settings.')}
-                        </div>
-                      )}
-                    </div>
+                    <PlayerSelectionSection
+                      availablePlayers={availablePlayersForSetup}
+                      selectedPlayerIds={selectedPlayerIds}
+                      onSelectedPlayersChange={setSelectedPlayerIds}
+                      title={t('newGameSetupModal.selectPlayers', 'Select Players')}
+                      playersSelectedText={t('newGameSetupModal.playersSelected', 'selected')}
+                      selectAllText={t('newGameSetupModal.selectAll', 'Select All')}
+                      noPlayersText={t('newGameSetupModal.noPlayersInRoster', 'No players in roster. Add players in Roster Settings.')}
+                      disabled={isLoading}
+                    />
 
                     {/* Game Settings Section */}
                     <div className="space-y-4 bg-slate-900/70 p-4 rounded-lg border border-slate-700 shadow-inner">

--- a/src/components/PlayerSelectionSection.tsx
+++ b/src/components/PlayerSelectionSection.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React from 'react';
+import { Player } from '@/types';
+
+export interface PlayerSelectionSectionProps {
+  availablePlayers: Player[];
+  selectedPlayerIds: string[];
+  onSelectedPlayersChange: (ids: string[]) => void;
+  title: string;
+  playersSelectedText: string; // like 'selected'
+  selectAllText: string;
+  noPlayersText: string;
+  disabled?: boolean;
+}
+
+const PlayerSelectionSection: React.FC<PlayerSelectionSectionProps> = ({
+  availablePlayers,
+  selectedPlayerIds,
+  onSelectedPlayersChange,
+  title,
+  playersSelectedText,
+  selectAllText,
+  noPlayersText,
+  disabled,
+}) => {
+  return (
+    <div className="space-y-4 bg-slate-900/70 p-4 rounded-lg border border-slate-700 shadow-inner">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-slate-200">{title}</h3>
+        <div className="text-sm text-slate-400">
+          <span className="text-yellow-400 font-semibold">{selectedPlayerIds.length}</span>{' / '}
+          <span className="text-yellow-400 font-semibold">{availablePlayers.length}</span>{' '}
+          {playersSelectedText}
+        </div>
+      </div>
+      {availablePlayers.length > 0 ? (
+        <>
+          <div className="flex items-center py-2 px-1 border-b border-slate-700/50">
+            <label className="flex items-center text-sm text-slate-300 hover:text-slate-200 cursor-pointer">
+              <input
+                type="checkbox"
+                disabled={disabled}
+                checked={availablePlayers.length === selectedPlayerIds.length}
+                onChange={() => {
+                  if (selectedPlayerIds.length === availablePlayers.length) {
+                    onSelectedPlayersChange([]);
+                  } else {
+                    onSelectedPlayersChange(availablePlayers.map((p) => p.id));
+                  }
+                }}
+                className="form-checkbox h-4 w-4 text-indigo-600 bg-slate-700 border-slate-500 rounded focus:ring-indigo-500 focus:ring-offset-slate-800"
+              />
+              <span className="ml-2">{selectAllText}</span>
+            </label>
+          </div>
+          <div className="space-y-1 max-h-48 overflow-y-auto pr-1">
+            {availablePlayers.map((player) => (
+              <div key={player.id} className="flex items-center py-1.5 px-1 rounded hover:bg-slate-800/40 transition-colors">
+                <label className="flex items-center flex-1 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    disabled={disabled}
+                    checked={selectedPlayerIds.includes(player.id)}
+                    onChange={() => {
+                      if (selectedPlayerIds.includes(player.id)) {
+                        onSelectedPlayersChange(selectedPlayerIds.filter((id) => id !== player.id));
+                      } else {
+                        onSelectedPlayersChange([...selectedPlayerIds, player.id]);
+                      }
+                    }}
+                    className="form-checkbox h-4 w-4 text-indigo-600 bg-slate-700 border-slate-500 rounded focus:ring-indigo-500 focus:ring-offset-slate-800"
+                  />
+                  <span className="ml-2 text-slate-200">
+                    {player.name}
+                    {player.nickname && <span className="text-slate-400 ml-1">({player.nickname})</span>}
+                  </span>
+                </label>
+              </div>
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="text-center py-4 text-slate-400">{noPlayersText}</div>
+      )}
+    </div>
+  );
+};
+
+export default PlayerSelectionSection;

--- a/src/components/TeamOpponentInputs.tsx
+++ b/src/components/TeamOpponentInputs.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React from 'react';
+
+export interface TeamOpponentInputsProps {
+  teamName: string;
+  opponentName: string;
+  onTeamNameChange: (value: string) => void;
+  onOpponentNameChange: (value: string) => void;
+  teamLabel: string;
+  teamPlaceholder: string;
+  opponentLabel: string;
+  opponentPlaceholder: string;
+  teamInputRef?: React.Ref<HTMLInputElement>;
+  opponentInputRef?: React.Ref<HTMLInputElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  disabled?: boolean;
+}
+
+const TeamOpponentInputs: React.FC<TeamOpponentInputsProps> = ({
+  teamName,
+  opponentName,
+  onTeamNameChange,
+  onOpponentNameChange,
+  teamLabel,
+  teamPlaceholder,
+  opponentLabel,
+  opponentPlaceholder,
+  teamInputRef,
+  opponentInputRef,
+  onKeyDown,
+  disabled,
+}) => {
+  return (
+    <>
+      <div className="mb-4">
+        <label htmlFor="teamNameInput" className="block text-sm font-medium text-slate-300 mb-1">
+          {teamLabel}
+        </label>
+        <input
+          type="text"
+          id="teamNameInput"
+          ref={teamInputRef}
+          value={teamName}
+          onChange={(e) => onTeamNameChange(e.target.value)}
+          placeholder={teamPlaceholder}
+          className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+          onKeyDown={onKeyDown}
+          disabled={disabled}
+        />
+      </div>
+      <div className="mb-4">
+        <label htmlFor="opponentNameInput" className="block text-sm font-medium text-slate-300 mb-1">
+          {opponentLabel}
+        </label>
+        <input
+          type="text"
+          id="opponentNameInput"
+          ref={opponentInputRef}
+          value={opponentName}
+          onChange={(e) => onOpponentNameChange(e.target.value)}
+          placeholder={opponentPlaceholder}
+          className="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded-md text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-indigo-500 focus:border-indigo-500 shadow-sm"
+          onKeyDown={onKeyDown}
+          disabled={disabled}
+        />
+      </div>
+    </>
+  );
+};
+
+export default TeamOpponentInputs;


### PR DESCRIPTION
## Summary
- extract `TeamOpponentInputs` for team/opponent name fields
- add `PlayerSelectionSection` for reusable player checklists
- refactor `GameSettingsModal` and `NewGameSetupModal` to use the new subcomponents

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ec3097250832cb83552da2a032d99