### PR TITLE
Fix console warnings in tests

### DIFF
--- a/src/components/GameStatsModal.test.tsx
+++ b/src/components/GameStatsModal.test.tsx
@@ -17,6 +17,30 @@ global.ResizeObserver = class ResizeObserver {
   disconnect() {}
 };
 
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: 800,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    value: 600,
+  });
+  HTMLElement.prototype.getBoundingClientRect = function () {
+    return {
+      width: 800,
+      height: 600,
+      top: 0,
+      left: 0,
+      bottom: 600,
+      right: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    } as DOMRect;
+  };
+});
+
 // Mocks
 jest.mock('@/utils/seasons');
 jest.mock('@/utils/tournaments');
@@ -151,9 +175,11 @@ const getDefaultProps = (): TestProps => ({
 // Helper to render with mocked context/providers if needed
 const renderComponent = (props: TestProps) => {
   return render(
-    <I18nextProvider i18n={i18n}>
-      <GameStatsModal {...props} />
-    </I18nextProvider>
+    <div style={{ width: 800, height: 600 }}>
+      <I18nextProvider i18n={i18n}>
+        <GameStatsModal {...props} />
+      </I18nextProvider>
+    </div>
   );
 };
 

--- a/src/components/PlayerAssessmentCard.test.tsx
+++ b/src/components/PlayerAssessmentCard.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n.test';
 import PlayerAssessmentCard from './PlayerAssessmentCard';
 import type { Player } from '@/types';
 
@@ -8,13 +10,21 @@ describe('PlayerAssessmentCard', () => {
   const player: Player = { id: 'p1', name: 'Test', jerseyNumber: '9' };
 
   it('renders player name', () => {
-    render(<PlayerAssessmentCard player={player} onSave={jest.fn()} />);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <PlayerAssessmentCard player={player} onSave={jest.fn()} />
+      </I18nextProvider>
+    );
     expect(screen.getByText('Test')).toBeInTheDocument();
   });
 
   it('calls onSave with assessment', () => {
     const onSave = jest.fn();
-    render(<PlayerAssessmentCard player={player} onSave={onSave} />);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <PlayerAssessmentCard player={player} onSave={onSave} />
+      </I18nextProvider>
+    );
     fireEvent.click(screen.getByText('Test'));
     fireEvent.click(screen.getByRole('button', { name: /Save/i }));
     expect(onSave).toHaveBeenCalled();
@@ -22,18 +32,20 @@ describe('PlayerAssessmentCard', () => {
 
   it('loads existing assessment values', () => {
     render(
-      <PlayerAssessmentCard
-        player={player}
-        onSave={jest.fn()}
-        assessment={{
-          overall: 7,
-          sliders: { intensity: 4, courage: 4, duels: 4, technique: 4, creativity: 4, decisions: 4, awareness: 4, teamwork: 4, fair_play: 4, impact: 4 },
-          notes: 'note',
-          minutesPlayed: 0,
-          createdAt: 0,
-          createdBy: 'test',
-        }}
-      />
+      <I18nextProvider i18n={i18n}>
+        <PlayerAssessmentCard
+          player={player}
+          onSave={jest.fn()}
+          assessment={{
+            overall: 7,
+            sliders: { intensity: 4, courage: 4, duels: 4, technique: 4, creativity: 4, decisions: 4, awareness: 4, teamwork: 4, fair_play: 4, impact: 4 },
+            notes: 'note',
+            minutesPlayed: 0,
+            createdAt: 0,
+            createdBy: 'test',
+          }}
+        />
+      </I18nextProvider>
     );
     fireEvent.click(screen.getByText('Test'));
     expect(screen.getByDisplayValue('note')).toBeInTheDocument();

--- a/src/components/UpdateBanner.test.tsx
+++ b/src/components/UpdateBanner.test.tsx
@@ -1,21 +1,35 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../i18n.test';
 import UpdateBanner from './UpdateBanner';
 
 describe('UpdateBanner', () => {
   it('renders release notes when provided', () => {
-    render(<UpdateBanner onUpdate={() => {}} notes="Some fixes" />);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <UpdateBanner onUpdate={() => {}} notes="Some fixes" />
+      </I18nextProvider>
+    );
     expect(screen.getByText('Some fixes')).toBeInTheDocument();
   });
 
   it('does not render notes when not provided', () => {
-    render(<UpdateBanner onUpdate={() => {}} />);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <UpdateBanner onUpdate={() => {}} />
+      </I18nextProvider>
+    );
     expect(screen.queryByText('Some fixes')).not.toBeInTheDocument();
   });
 
   it('hides banner when dismissed', () => {
-    render(<UpdateBanner onUpdate={() => {}} />);
+    render(
+      <I18nextProvider i18n={i18n}>
+        <UpdateBanner onUpdate={() => {}} />
+      </I18nextProvider>
+    );
     const button = screen.getByRole('button', { name: /dismiss/i });
     button.click();
     expect(screen.queryByText(/new version/i)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- wrap `UpdateBanner` and `PlayerAssessmentCard` tests with `I18nextProvider`
- ensure `GameStatsModal` tests run with fixed container dimensions

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687f39763628832cb9193999e68f270c