### PR TITLE
Fix storage config options

### DIFF
--- a/src/lib/storage/__tests__/config.test.ts
+++ b/src/lib/storage/__tests__/config.test.ts
@@ -51,11 +51,27 @@ describe('Storage Configuration', () => {
       process.env.NEXT_PUBLIC_DISABLE_FALLBACK = 'true';
 
       const config = getStorageConfig();
-      
+
       expect(config).toEqual({
         provider: 'supabase',
         fallbackToLocalStorage: false,
       });
+    });
+
+    it('should use localStorage when user is not authenticated', () => {
+      process.env.NEXT_PUBLIC_ENABLE_SUPABASE = 'true';
+
+      const config = getStorageConfig({ isAuthenticated: false });
+
+      expect(config.provider).toBe('localStorage');
+    });
+
+    it('should use supabase when enabled and authenticated', () => {
+      process.env.NEXT_PUBLIC_ENABLE_SUPABASE = 'true';
+
+      const config = getStorageConfig({ isAuthenticated: true });
+
+      expect(config.provider).toBe('supabase');
     });
   });
 

--- a/src/lib/storage/config.ts
+++ b/src/lib/storage/config.ts
@@ -12,12 +12,20 @@ export const DEFAULT_STORAGE_CONFIG: StorageConfig = {
 /**
  * Get storage configuration based on feature flags
  */
-export function getStorageConfig(): StorageConfig {
-  const enableSupabase = process.env.NEXT_PUBLIC_ENABLE_SUPABASE === 'true';
+export interface StorageConfigOptions {
+  isAuthenticated?: boolean;
+  enableSupabase?: boolean;
+}
+
+export function getStorageConfig(options: StorageConfigOptions = {}): StorageConfig {
+  const envSupabase = process.env.NEXT_PUBLIC_ENABLE_SUPABASE === 'true';
+  const enableSupabase = options.enableSupabase ?? envSupabase;
   const disableFallback = process.env.NEXT_PUBLIC_DISABLE_FALLBACK === 'true';
-  
+
+  const useSupabase = enableSupabase && (options.isAuthenticated ?? true);
+
   return {
-    provider: enableSupabase ? 'supabase' : 'localStorage',
+    provider: useSupabase ? 'supabase' : 'localStorage',
     fallbackToLocalStorage: !disableFallback,
   };
 }


### PR DESCRIPTION
## Summary
- allow passing options to `getStorageConfig`
- test authenticated/unauthenticated paths for storage config

## Testing
- `npm run lint`
- `npm test` *(fails: RangeError: Maximum call stack size exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_688148381224832cabb63a87af3db064