### PR TITLE
Fix tests for storage error handling

### DIFF
--- a/src/context/__tests__/AuthContext.test.tsx
+++ b/src/context/__tests__/AuthContext.test.tsx
@@ -55,8 +55,12 @@ const TestComponent = ({ testId = 'test-component' }: { testId?: string }) => {
   );
 };
 
-const renderWithAuthProvider = (children: ReactNode) => {
-  return render(<AuthProvider>{children}</AuthProvider>);
+const renderWithAuthProvider = async (children: ReactNode) => {
+  let utils: ReturnType<typeof render> | undefined;
+  await act(async () => {
+    utils = render(<AuthProvider>{children}</AuthProvider>);
+  });
+  return utils as ReturnType<typeof render>;
 };
 
 describe('AuthContext', () => {
@@ -98,7 +102,7 @@ describe('AuthContext', () => {
 
   describe('Initialization', () => {
     it('should initialize with null user and session, and loading true', async () => {
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       expect(screen.getByTestId('user')).toHaveTextContent('null');
       expect(screen.getByTestId('session')).toHaveTextContent('null');
@@ -111,7 +115,7 @@ describe('AuthContext', () => {
     });
 
     it('should call getSession and getUser on mount', async () => {
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(mockSupabase.auth.getSession).toHaveBeenCalled();
@@ -119,8 +123,8 @@ describe('AuthContext', () => {
       });
     });
 
-    it('should set up auth state change listener', () => {
-      renderWithAuthProvider(<TestComponent />);
+    it('should set up auth state change listener', async () => {
+      await renderWithAuthProvider(<TestComponent />);
       
       expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalled();
     });
@@ -141,7 +145,7 @@ describe('AuthContext', () => {
         error: null,
       });
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('user')).toHaveTextContent(JSON.stringify(mockUser));
@@ -158,7 +162,7 @@ describe('AuthContext', () => {
         return { data: { subscription: { unsubscribe: mockUnsubscribe } } };
       });
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       // Wait for initial load
       await waitFor(() => {
@@ -190,7 +194,7 @@ describe('AuthContext', () => {
         error: null,
       });
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');
@@ -216,7 +220,7 @@ describe('AuthContext', () => {
         error: mockError,
       });
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');
@@ -240,7 +244,7 @@ describe('AuthContext', () => {
         error: null,
       });
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');
@@ -259,7 +263,7 @@ describe('AuthContext', () => {
     });
 
     it('should handle sign out', async () => {
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');
@@ -275,7 +279,7 @@ describe('AuthContext', () => {
     });
 
     it('should handle password reset', async () => {
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');
@@ -294,8 +298,8 @@ describe('AuthContext', () => {
   });
 
   describe('Cleanup', () => {
-    it('should unsubscribe from auth state changes on unmount', () => {
-      const { unmount } = renderWithAuthProvider(<TestComponent />);
+    it('should unsubscribe from auth state changes on unmount', async () => {
+      const { unmount } = await renderWithAuthProvider(<TestComponent />);
       
       unmount();
       
@@ -307,7 +311,7 @@ describe('AuthContext', () => {
     it('should handle getSession errors gracefully', async () => {
       mockSupabase.auth.getSession.mockRejectedValue(new Error('Session error'));
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');
@@ -319,7 +323,7 @@ describe('AuthContext', () => {
     it('should handle getUser errors gracefully', async () => {
       mockSupabase.auth.getUser.mockRejectedValue(new Error('User error'));
       
-      renderWithAuthProvider(<TestComponent />);
+      await renderWithAuthProvider(<TestComponent />);
       
       await waitFor(() => {
         expect(screen.getByTestId('loading')).toHaveTextContent('false');

--- a/src/utils/savedGames.test.ts
+++ b/src/utils/savedGames.test.ts
@@ -155,7 +155,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage failure'); 
       });
-      await expect(getGame('game_123')).rejects.toThrow('LocalStorage failure');
+      await expect(getGame('game_123')).rejects.toThrow('Failed to get saved games');
     });
   });
 
@@ -225,14 +225,14 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage failure'); 
       });
-      await expect(saveGame('game_123', mockGame1_AppState)).rejects.toThrow('LocalStorage failure');
+      await expect(saveGame('game_123', mockGame1_AppState)).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGames fails', async () => {
-      localStorageMock.setItem.mockImplementation(() => { 
-        throw new Error('LocalStorage set failure'); 
+      localStorageMock.setItem.mockImplementation(() => {
+        throw new Error('LocalStorage set failure');
       });
-      await expect(saveGame('game_123', mockGame1_AppState)).rejects.toThrow('LocalStorage set failure');
+      await expect(saveGame('game_123', mockGame1_AppState)).rejects.toThrow('Failed to save game');
     });
   });
 
@@ -267,14 +267,14 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage failure'); 
       });
-      await expect(deleteGame('game_123')).rejects.toThrow('LocalStorage failure');
+      await expect(deleteGame('game_123')).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGames (after delete) fails', async () => {
       localStorageMock.setItem.mockImplementation(() => { 
         throw new Error('LocalStorage set failure after delete'); 
       });
-      await expect(deleteGame('game_123')).rejects.toThrow('LocalStorage set failure after delete');
+      await expect(deleteGame('game_123')).rejects.toThrow('Failed to delete saved game');
     });
   });
 
@@ -336,7 +336,7 @@ describe('Saved Games Utilities', () => {
       });
       const initialGamePartial: Partial<AppState> = { teamName: 'Fail Team' };
       
-      await expect(createGame(initialGamePartial)).rejects.toThrow('LocalStorage set failure during create');
+      await expect(createGame(initialGamePartial)).rejects.toThrow('Failed to save game');
     });
   });
 
@@ -374,7 +374,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage get failure'); 
       });
-      await expect(addGameEvent('game_123', mockEvent1)).rejects.toThrow('LocalStorage get failure');
+      await expect(addGameEvent('game_123', mockEvent1)).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGame fails', async () => {
@@ -387,7 +387,7 @@ describe('Saved Games Utilities', () => {
         await addGameEvent('game_123', mockEvent1);
         throw new Error('addGameEvent did not reject as expected');
       } catch (error) {
-        expect((error as Error).message).toBe('LocalStorage set failure');
+        expect((error as Error).message).toBe('Failed to save game');
       }
     });
   });
@@ -431,7 +431,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage get failure'); 
       });
-      await expect(updateGameEvent('game_123', 0, mockEvent1)).rejects.toThrow('LocalStorage get failure');
+      await expect(updateGameEvent('game_123', 0, mockEvent1)).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGame fails', async () => {
@@ -445,7 +445,7 @@ describe('Saved Games Utilities', () => {
         await updateGameEvent('game_123', 0, eventData);
         throw new Error('updateGameEvent did not reject as expected');
       } catch (error) {
-        expect((error as Error).message).toBe('LocalStorage set failure');
+        expect((error as Error).message).toBe('Failed to save game');
       }
     });
   });
@@ -488,7 +488,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage get failure'); 
       });
-      await expect(removeGameEvent('game_123', 0)).rejects.toThrow('LocalStorage get failure');
+      await expect(removeGameEvent('game_123', 0)).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGame fails', async () => {
@@ -501,7 +501,7 @@ describe('Saved Games Utilities', () => {
         await removeGameEvent('game_123', 0);
         throw new Error('removeGameEvent did not reject as expected');
       } catch (error) {
-        expect((error as Error).message).toBe('LocalStorage set failure');
+        expect((error as Error).message).toBe('Failed to save game');
       }
     });
   });
@@ -528,7 +528,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage failure'); 
       });
-      await expect(exportGamesAsJson()).rejects.toThrow('LocalStorage failure');
+      await expect(exportGamesAsJson()).rejects.toThrow('Failed to get saved games');
     });
   });
 
@@ -600,7 +600,7 @@ describe('Saved Games Utilities', () => {
       });
       const gamesToImport: SavedGamesCollection = { 'new_game': mockGame2_AppState };
       const jsonData = JSON.stringify(gamesToImport);
-      await expect(importGamesFromJson(jsonData, false)).rejects.toThrow('LocalStorage get failure');
+      await expect(importGamesFromJson(jsonData, false)).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGames fails during import', async () => {
@@ -612,7 +612,7 @@ describe('Saved Games Utilities', () => {
       });
       const gamesToImport: SavedGamesCollection = { 'new_game': mockGame2_AppState };
       const jsonData = JSON.stringify(gamesToImport);
-      await expect(importGamesFromJson(jsonData, false)).rejects.toThrow('LocalStorage set failure during import');
+      await expect(importGamesFromJson(jsonData, false)).rejects.toThrow('Failed to save game');
     });
 
   });
@@ -640,7 +640,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => { 
         throw new Error('LocalStorage failure'); 
       });
-      await expect(getAllGameIds()).rejects.toThrow('LocalStorage failure');
+      await expect(getAllGameIds()).rejects.toThrow('Failed to get saved games');
     });
   });
 
@@ -695,7 +695,7 @@ describe('Saved Games Utilities', () => {
       localStorageMock.getItem.mockImplementation(() => {
         throw new Error('LocalStorage get failure for filter');
       });
-      await expect(getFilteredGames({ seasonId: 'season_1' })).rejects.toThrow('LocalStorage get failure for filter');
+      await expect(getFilteredGames({ seasonId: 'season_1' })).rejects.toThrow('Failed to get saved games');
     });
   });
 
@@ -756,7 +756,7 @@ describe('Saved Games Utilities', () => {
         throw new Error('LocalStorage get failure for update'); 
       });
       const updates: Partial<AppState> = { teamName: 'Still Matters Not' };
-      await expect(updateGameDetails('game_123', updates)).rejects.toThrow('LocalStorage get failure for update');
+      await expect(updateGameDetails('game_123', updates)).rejects.toThrow('Failed to get saved games');
     });
 
     it('should reject if internal saveGame (after update) fails', async () => {
@@ -770,7 +770,7 @@ describe('Saved Games Utilities', () => {
         await updateGameDetails('game_123', updates);
         throw new Error('updateGameDetails did not reject as expected');
       } catch (error) {
-        expect((error as Error).message).toBe('LocalStorage set failure for update');
+        expect((error as Error).message).toBe('Failed to save game');
       }
     });
   });


### PR DESCRIPTION
## Summary
- update AuthContext tests to wrap render with `act`
- update savedGames tests to expect new `StorageError` messages

## Testing
- `npm run lint`
- `npm test -- -w=1` *(fails: 21 failed, 57 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68854dd25780832ca9695460570b045c