### PR TITLE
Fix Wake Lock vendor type

### DIFF
--- a/src/lib/native/deviceIntegration.ts
+++ b/src/lib/native/deviceIntegration.ts
@@ -20,11 +20,11 @@ interface VendorDocument extends Document {
   msExitFullscreen?: () => Promise<void> | void;
 }
 
-interface VendorNavigator extends Navigator {
+type VendorNavigator = Omit<Navigator, 'wakeLock'> & {
   wakeLock?: {
     request: (type: 'screen') => Promise<WakeLockSentinel>;
   };
-}
+};
 
 
 interface DeviceCapabilities {


### PR DESCRIPTION
## Summary
- adjust custom navigator interface to omit wakeLock

## Testing
- `npm run lint`
- `npm test -- -w=1` *(fails: 11 failed, 80 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688a950fde0c832c88d41f5668e3bbca