### PR TITLE
Fix notification data type

### DIFF
--- a/src/lib/notifications/pushNotificationManager.ts
+++ b/src/lib/notifications/pushNotificationManager.ts
@@ -3,13 +3,18 @@
  * Handles push notification subscriptions, permissions, and messaging for game alerts and sync notifications
  */
 
+interface NotificationData {
+  url?: string;
+  [key: string]: unknown;
+}
+
 interface NotificationConfig {
   title: string;
   body: string;
   icon?: string;
   badge?: string;
   tag?: string;
-  data?: Record<string, unknown>;
+  data?: NotificationData;
   actions?: NotificationAction[];
   requireInteraction?: boolean;
   silent?: boolean;

--- a/src/lib/serviceWorker/backgroundSync.ts
+++ b/src/lib/serviceWorker/backgroundSync.ts
@@ -16,8 +16,8 @@ interface BackgroundSyncOptions {
 
 interface SyncResult {
   success: boolean;
-  processed: number;
-  failed: number;
+  syncedItems: number;
+  failedItems: number;
   errors: string[];
 }
 
@@ -66,17 +66,19 @@ export class BackgroundSyncHandler {
       
       return {
         success: result.success,
-        processed: result.processed || 0,
-        failed: result.failed || 0,
-        errors: result.errors || []
+        syncedItems: result.syncedItems || 0,
+        failedItems: result.failedItems || 0,
+        errors: result.errors.map(e =>
+          e instanceof Error ? e.message : String(e)
+        )
       };
     } catch (error) {
       console.error('[BG-Sync] Background sync failed:', error);
       
       return {
         success: false,
-        processed: 0,
-        failed: 1,
+        syncedItems: 0,
+        failedItems: 1,
         errors: [error instanceof Error ? error.message : 'Unknown error']
       };
     }
@@ -100,7 +102,7 @@ export class BackgroundSyncHandler {
       if (operation) {
         await this.syncManager.queueOperation(
           operation.action,
-          operation.table,
+          operation.table as keyof import('../storage/indexedDBProvider').IndexedDBSchema,
           operation.data
         );
       }


### PR DESCRIPTION
## Summary
- add a `NotificationData` interface for push notifications
- align background sync result type with `SyncManager`

## Testing
- `npm run lint`
- `npm test` *(fails: 45 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688a96e62280832c91131c9300ad1e58