### PR TITLE
Fix assister save issue

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -302,9 +302,37 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
     // masterRosterKey: MASTER_ROSTER_KEY, // Removed as no longer used by useGameState
   });
 
+  const handleQuickSaveGameRef = useRef<(() => void) | null>(null);
+
+  const handlePlayerIdUpdated = useCallback(
+    (oldId: string, newId: string) => {
+      setPlayersOnField(prev => prev.map(p => (p.id === oldId ? { ...p, id: newId } : p)));
+
+      dispatchGameSession({
+        type: 'SET_SELECTED_PLAYER_IDS',
+        payload: gameSessionState.selectedPlayerIds.map(id => (id === oldId ? newId : id)),
+      });
+
+      gameSessionState.gameEvents.forEach(event => {
+        if (event.scorerId === oldId || event.assisterId === oldId) {
+          const updatedEvent = {
+            ...event,
+            scorerId: event.scorerId === oldId ? newId : event.scorerId,
+            assisterId: event.assisterId === oldId ? newId : event.assisterId,
+          };
+          dispatchGameSession({ type: 'UPDATE_GAME_EVENT', payload: updatedEvent });
+        }
+      });
+
+      handleQuickSaveGameRef.current?.();
+    },
+    [setPlayersOnField, dispatchGameSession, gameSessionState.selectedPlayerIds, gameSessionState.gameEvents]
+  );
+
   const roster = useRoster({
     initialPlayers: initialState.availablePlayers,
     selectedPlayerIds: gameSessionState.selectedPlayerIds,
+    onPlayerIdUpdated: handlePlayerIdUpdated,
   });
   const {
     availablePlayers,
@@ -524,6 +552,10 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
     tacticalDrawings,
     tacticalBallPosition,
   });
+
+  useEffect(() => {
+    handleQuickSaveGameRef.current = handleQuickSaveGame;
+  }, [handleQuickSaveGame]);
 
   // --- Game State Management (Extracted to useGameStateManager hook) ---
   const {

--- a/src/hooks/useRoster.ts
+++ b/src/hooks/useRoster.ts
@@ -7,9 +7,10 @@ import { useCacheManager } from '@/utils/cacheUtils';
 interface UseRosterArgs {
   initialPlayers: Player[];
   selectedPlayerIds: string[];
+  onPlayerIdUpdated?: (tempId: string, newId: string) => void;
 }
 
-export const useRoster = ({ initialPlayers, selectedPlayerIds }: UseRosterArgs) => {
+export const useRoster = ({ initialPlayers, selectedPlayerIds, onPlayerIdUpdated }: UseRosterArgs) => {
   const queryClient = useQueryClient();
   const cacheManager = useCacheManager(queryClient);
   const [availablePlayers, setAvailablePlayers] = useState<Player[]>(initialPlayers);
@@ -53,12 +54,16 @@ export const useRoster = ({ initialPlayers, selectedPlayerIds }: UseRosterArgs) 
         setAvailablePlayers((players) =>
           players.map((p) => (p.id === temp.id ? saved : p)),
         );
-        
+
         // Update cache with real data
         cacheManager.updateMasterRosterCache((players) =>
           players.map((p) => (p.id === temp.id ? saved : p))
         );
-        
+
+        if (onPlayerIdUpdated) {
+          onPlayerIdUpdated(temp.id, saved.id);
+        }
+
         setRosterError(null);
       } else {
         // Rollback optimistic updates


### PR DESCRIPTION
## Summary
- notify when a temp player ID gets replaced with a saved one
- update players on field, selected IDs and events when a player's ID changes
- trigger a quick save after IDs update so events with assists persist

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d28d15f04832c8497c6297f82c856