### PR TITLE
Fix assister game event persistence

### DIFF
--- a/src/lib/storage/supabaseProvider.ts
+++ b/src/lib/storage/supabaseProvider.ts
@@ -5,7 +5,7 @@ import type { Player, Season, Tournament } from '../../types';
 import type { AppSettings } from '../../utils/appSettings';
 import { supabase } from '../supabase';
 import { toSupabase, fromSupabase } from '../../utils/transforms';
-import type { DbSeason, DbTournament, DbPlayer, DbAppSettings, DbGame } from '../../utils/transforms';
+import type { DbSeason, DbTournament, DbPlayer, DbAppSettings, DbGame, SupabaseGameEvent } from '../../utils/transforms';
 import { compressionManager, FIELD_SELECTIONS } from './compressionUtils';
 
 export class SupabaseProvider implements IStorageProvider {
@@ -499,14 +499,9 @@ export class SupabaseProvider implements IStorageProvider {
               .eq('game_id', game.id);
             
             if (events && events.length > 0) {
-              currentGame.gameEvents = events.map((e: Record<string, unknown>) => ({
-                id: e.id,
-                type: e.event_type,
-                time: e.time_seconds,
-                scorerId: e.scorer_id,
-                assisterId: e.assister_id,
-                entityId: e.entity_id
-              }));
+              currentGame.gameEvents = events.map(e =>
+                fromSupabase.gameEvent(e as SupabaseGameEvent)
+              );
             }
           }
         } catch {


### PR DESCRIPTION
## Summary
- ensure Supabase events use transform function
- normalize assister data when loading games from Supabase

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d3251e928832cadf6f19456ca5732