### PR TITLE
Fix goal logging for scorer only or with assist

### DIFF
--- a/src/hooks/useGameEventsManager.ts
+++ b/src/hooks/useGameEventsManager.ts
@@ -41,8 +41,12 @@ export const useGameEventsManager = ({
    * Handler to add a goal event
    */
   const handleAddGoalEvent = useCallback((scorerId: string, assisterId?: string) => {
-    const scorer = (masterRosterQueryResultData || availablePlayers).find(p => p.id === scorerId);
-    const assister = assisterId ? (masterRosterQueryResultData || availablePlayers).find(p => p.id === assisterId) : undefined;
+    const rosterSource = masterRosterQueryResultData && masterRosterQueryResultData.length > 0
+      ? masterRosterQueryResultData
+      : availablePlayers;
+
+    const scorer = rosterSource.find(p => p.id === scorerId);
+    const assister = assisterId ? rosterSource.find(p => p.id === assisterId) : undefined;
 
     if (!scorer) {
       logger.error("Scorer not found!");


### PR DESCRIPTION
## Summary
- ensure roster lookup falls back to available players when master roster not loaded
- run lint and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d38780210832cb640478fc1a2d87a