### PR TITLE
chore: remove tournament provider debug logs

### DIFF
--- a/src/lib/storage/supabaseProvider.ts
+++ b/src/lib/storage/supabaseProvider.ts
@@ -304,15 +304,6 @@ export class SupabaseProvider implements IStorageProvider {
       
       const supabaseTournament = toSupabase.tournament(tournamentForSupabase, userId);
 
-      // Debug: Log what we're trying to save (remove in production)
-      if (process.env.NODE_ENV === 'development') {
-        console.log('[SupabaseProvider] Tournament save data:', {
-          tournament: tournament.name,
-          isLocalId,
-          hasId: Boolean(tournamentForSupabase.id)
-        });
-      }
-
       let result;
       if (tournamentForSupabase.id && !isLocalId) {
         // Update existing tournament
@@ -384,13 +375,6 @@ export class SupabaseProvider implements IStorageProvider {
     try {
       const userId = await this.getCurrentUserId();
       const supabaseUpdates = toSupabase.tournamentUpdate(updates, userId);
-
-      // Debug: Log what we're trying to update
-      console.log('[SupabaseProvider] Tournament update data:', {
-        tournamentId,
-        updates,
-        supabaseUpdates
-      });
 
       const { data, error } = await supabase
         .from('tournaments')


### PR DESCRIPTION
## Summary
- remove leftover debug console.log from saveTournament and updateTournament to prevent console noise

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e7f92197c832ca04ff870e73892eb