### PR TITLE
Ensure Supabase deletions detect missing records

### DIFF
--- a/src/lib/storage/supabaseProvider.test.ts
+++ b/src/lib/storage/supabaseProvider.test.ts
@@ -1,0 +1,63 @@
+jest.mock('../supabase', () => {
+  const mockMaybeSingle = jest.fn();
+  const mockSelect = jest.fn(() => ({ maybeSingle: mockMaybeSingle }));
+  const mockEq = jest.fn(() => ({ eq: mockEq, select: mockSelect }));
+  const mockDelete = jest.fn(() => ({ eq: mockEq, select: mockSelect }));
+  const mockFrom = jest.fn(() => ({ delete: mockDelete }));
+  const mockGetUser = jest
+    .fn()
+    .mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+
+  return {
+    supabase: {
+      from: mockFrom,
+      auth: { getUser: mockGetUser },
+      __mock: { mockMaybeSingle, mockSelect, mockEq, mockDelete, mockFrom, mockGetUser }
+    }
+  };
+});
+
+import { SupabaseProvider } from './supabaseProvider';
+import { supabase } from '../supabase';
+
+const { mockMaybeSingle, mockGetUser } = (supabase as unknown as {
+  __mock: {
+    mockMaybeSingle: jest.Mock;
+    mockGetUser: jest.Mock;
+  };
+}).__mock;
+
+describe('SupabaseProvider delete methods', () => {
+  let provider: SupabaseProvider;
+
+  beforeEach(() => {
+    provider = new SupabaseProvider();
+    jest.clearAllMocks();
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1' } },
+      error: null
+    });
+  });
+
+  it('throws StorageError when deleting non-existent player', async () => {
+    await expect(provider.deletePlayer('missing'))
+      .rejects.toThrow('Player not found');
+  });
+
+  it('throws StorageError when deleting non-existent season', async () => {
+    await expect(provider.deleteSeason('missing'))
+      .rejects.toThrow('Season not found');
+  });
+
+  it('throws StorageError when deleting non-existent tournament', async () => {
+    await expect(provider.deleteTournament('missing'))
+      .rejects.toThrow('Tournament not found');
+  });
+
+  it('throws StorageError when deleting non-existent saved game', async () => {
+    await expect(provider.deleteSavedGame('missing'))
+      .rejects.toThrow('Saved game not found');
+  });
+});
+

--- a/src/lib/storage/supabaseProvider.ts
+++ b/src/lib/storage/supabaseProvider.ts
@@ -109,17 +109,23 @@ export class SupabaseProvider implements IStorageProvider {
   async deletePlayer(playerId: string): Promise<void> {
     try {
       const userId = await this.getCurrentUserId();
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from('players')
         .delete()
         .eq('id', playerId)
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .select('id')
+        .maybeSingle();
 
       if (error) {
         throw new NetworkError('supabase', 'deletePlayer', error);
       }
+
+      if (!data) {
+        throw new StorageError('Player not found', 'supabase', 'deletePlayer');
+      }
     } catch (error) {
-      if (error instanceof AuthenticationError || error instanceof NetworkError) {
+      if (error instanceof AuthenticationError || error instanceof NetworkError || error instanceof StorageError) {
         throw error;
       }
       throw new StorageError('Failed to delete player', 'supabase', 'deletePlayer', error as Error);
@@ -228,17 +234,23 @@ export class SupabaseProvider implements IStorageProvider {
   async deleteSeason(seasonId: string): Promise<void> {
     try {
       const userId = await this.getCurrentUserId();
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from('seasons')
         .delete()
         .eq('id', seasonId)
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .select('id')
+        .maybeSingle();
 
       if (error) {
         throw new NetworkError('supabase', 'deleteSeason', error);
       }
+
+      if (!data) {
+        throw new StorageError('Season not found', 'supabase', 'deleteSeason');
+      }
     } catch (error) {
-      if (error instanceof AuthenticationError || error instanceof NetworkError) {
+      if (error instanceof AuthenticationError || error instanceof NetworkError || error instanceof StorageError) {
         throw error;
       }
       throw new StorageError('Failed to delete season', 'supabase', 'deleteSeason', error as Error);
@@ -354,17 +366,23 @@ export class SupabaseProvider implements IStorageProvider {
   async deleteTournament(tournamentId: string): Promise<void> {
     try {
       const userId = await this.getCurrentUserId();
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from('tournaments')
         .delete()
         .eq('id', tournamentId)
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .select('id')
+        .maybeSingle();
 
       if (error) {
         throw new NetworkError('supabase', 'deleteTournament', error);
       }
+
+      if (!data) {
+        throw new StorageError('Tournament not found', 'supabase', 'deleteTournament');
+      }
     } catch (error) {
-      if (error instanceof AuthenticationError || error instanceof NetworkError) {
+      if (error instanceof AuthenticationError || error instanceof NetworkError || error instanceof StorageError) {
         throw error;
       }
       throw new StorageError('Failed to delete tournament', 'supabase', 'deleteTournament', error as Error);
@@ -552,17 +570,23 @@ export class SupabaseProvider implements IStorageProvider {
   async deleteSavedGame(gameId: string): Promise<void> {
     try {
       const userId = await this.getCurrentUserId();
-      const { error } = await supabase
+      const { data, error } = await supabase
         .from('games')
         .delete()
         .eq('id', gameId)
-        .eq('user_id', userId);
+        .eq('user_id', userId)
+        .select('id')
+        .maybeSingle();
 
       if (error) {
         throw new NetworkError('supabase', 'deleteSavedGame', error);
       }
+
+      if (!data) {
+        throw new StorageError('Saved game not found', 'supabase', 'deleteSavedGame');
+      }
     } catch (error) {
-      if (error instanceof AuthenticationError || error instanceof NetworkError) {
+      if (error instanceof AuthenticationError || error instanceof NetworkError || error instanceof StorageError) {
         throw error;
       }
       throw new StorageError('Failed to delete saved game', 'supabase', 'deleteSavedGame', error as Error);


### PR DESCRIPTION
## Summary
- Verify Supabase delete calls by selecting the deleted `id` and throwing `StorageError` when not found
- Add unit tests covering missing record deletions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e819b2950832c9b2ff6745930f14f