### PR TITLE
Automatically quick save new games on creation

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1601,6 +1601,9 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
       // Re-enable auto-save after new game creation is complete
       setIsCreatingNewGame(false);
 
+      // Trigger an initial quick save so the game is persisted immediately
+      handleQuickSaveGame(actualGameId);
+
   }, [
     // Keep necessary dependencies
     savedGames,
@@ -1611,6 +1614,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
     setIsNewGameSetupModalOpen,
     setHighlightRosterButton,
     setIsCreatingNewGame,
+    handleQuickSaveGame,
   ]);
 
   // ** REVERT handleCancelNewGameSetup TO ORIGINAL **


### PR DESCRIPTION
## Summary
- allow quick-save handler to accept an optional game ID override
- trigger a quick save immediately after creating a new game so it's persisted without manual action

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fccc4b2f0832c8c46a808ffcfab0b