### PR TITLE
Handle quick save failures when starting new game

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1599,6 +1599,13 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
       setCurrentGameId(actualGameId);
       logger.log(`Set current game ID to: ${actualGameId}. Loading useEffect will sync component state.`);
 
+      try {
+        await handleQuickSaveGame(actualGameId);
+      } catch (error) {
+        logger.error('[handleStartNewGameWithSetup] Quick save failed:', error);
+        throw error;
+      }
+
       // Close the setup modal
       setIsNewGameSetupModalOpen(false);
       setNewGameDemandFactor(1);
@@ -1619,6 +1626,7 @@ function HomePage({ initialAction, skipInitialSetup = false }: HomePageProps) {
     setIsNewGameSetupModalOpen,
     setHighlightRosterButton,
     setIsCreatingNewGame,
+    handleQuickSaveGame,
   ]);
 
   // ** REVERT handleCancelNewGameSetup TO ORIGINAL **

--- a/src/components/NewGameSetupModal.tsx
+++ b/src/components/NewGameSetupModal.tsx
@@ -39,7 +39,7 @@ interface NewGameSetupModalProps {
     ageGroup: string,
     tournamentLevel: string,
     isPlayed: boolean
-  ) => void;
+  ) => Promise<void>;
   onCancel: () => void;
   addSeasonMutation: UseMutationResult<Season | null, Error, Partial<Season> & { name: string }, unknown>;
   addTournamentMutation: UseMutationResult<Tournament | null, Error, Partial<Tournament> & { name: string }, unknown>;
@@ -391,23 +391,27 @@ const NewGameSetupModal: React.FC<NewGameSetupModalProps> = ({
     // --- End Save ---
 
     // Call the onStart callback from props using the modal's internal selectedPlayerIds state
-    onStart(
-      selectedPlayerIds, // MODIFIED: Use the modal's current selection state
-      trimmedHomeTeamName,
-      trimmedOpponentName,
-      gameDate,
-      gameLocation.trim(),
-      gameTime,
-      selectedSeasonId,
-      selectedTournamentId,
-      localNumPeriods,
-      duration, // use validated duration
-      localHomeOrAway, // <<< Step 4a: Pass Home/Away >>>
-      demandFactor,
-      ageGroup,
-      tournamentLevel,
-      isPlayed
-    );
+    try {
+      await onStart(
+        selectedPlayerIds, // MODIFIED: Use the modal's current selection state
+        trimmedHomeTeamName,
+        trimmedOpponentName,
+        gameDate,
+        gameLocation.trim(),
+        gameTime,
+        selectedSeasonId,
+        selectedTournamentId,
+        localNumPeriods,
+        duration, // use validated duration
+        localHomeOrAway, // <<< Step 4a: Pass Home/Away >>>
+        demandFactor,
+        ageGroup,
+        tournamentLevel,
+        isPlayed
+      );
+    } catch (error) {
+      logger.error('[NewGameSetupModal] Failed to start new game:', error);
+    }
 
     // Modal will be closed by parent component after onStart
   };


### PR DESCRIPTION
## Summary
- ensure `handleStartNewGameWithSetup` awaits quick save and reports errors
- allow `NewGameSetupModal` to await async start handler and log failures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890590a1dfc832c98135af4324844f5