### PR TITLE
refactor: address lint warnings

### DIFF
--- a/src/app/admin/monitoring/page.tsx
+++ b/src/app/admin/monitoring/page.tsx
@@ -45,7 +45,7 @@ interface MetricsData {
       external: number;
       unit: string;
     };
-    cpu: any;
+    cpu: unknown;
   };
   sentry: {
     enabled: boolean;

--- a/src/app/import-backup/page.tsx
+++ b/src/app/import-backup/page.tsx
@@ -78,7 +78,7 @@ export default function ImportBackupPage() {
   };
 
   const importBackupData = async (jsonContent: string) => {
-    const parseResult = safeImportDataParse(jsonContent, (data): data is any => {
+    const parseResult = safeImportDataParse(jsonContent, (data): data is Record<string, unknown> => {
       return typeof data === 'object' && data !== null;
     });
     
@@ -230,35 +230,38 @@ export default function ImportBackupPage() {
           
           // Update availablePlayers with new IDs (if present)
           if (gameWithoutId.availablePlayers && Array.isArray(gameWithoutId.availablePlayers)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            gameWithoutId.availablePlayers = gameWithoutId.availablePlayers.map((player: any) => ({
-              ...player,
-              id: playerIdMap.get(player.id) || player.id
-            }));
+            gameWithoutId.availablePlayers = gameWithoutId.availablePlayers.map(
+              (player: { id: string } & Record<string, unknown>) => ({
+                ...player,
+                id: playerIdMap.get(player.id) || player.id
+              })
+            );
           }
           
           // Update playersOnField with new IDs
           if (gameWithoutId.playersOnField && Array.isArray(gameWithoutId.playersOnField)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            gameWithoutId.playersOnField = gameWithoutId.playersOnField.map((fieldPlayer: any) => ({
-              ...fieldPlayer,
-              id: playerIdMap.get(fieldPlayer.id) || fieldPlayer.id
-            }));
+            gameWithoutId.playersOnField = gameWithoutId.playersOnField.map(
+              (fieldPlayer: { id: string } & Record<string, unknown>) => ({
+                ...fieldPlayer,
+                id: playerIdMap.get(fieldPlayer.id) || fieldPlayer.id
+              })
+            );
           }
           
           // Update gameEvents with new player IDs
           if (gameWithoutId.gameEvents && Array.isArray(gameWithoutId.gameEvents)) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            gameWithoutId.gameEvents = gameWithoutId.gameEvents.map((event: any) => {
-              const updatedEvent = { ...event };
-              if (event.scorerId) {
-                updatedEvent.scorerId = playerIdMap.get(event.scorerId) || event.scorerId;
+            gameWithoutId.gameEvents = gameWithoutId.gameEvents.map(
+              (event: { scorerId?: string; assisterId?: string } & Record<string, unknown>) => {
+                const updatedEvent = { ...event };
+                if (event.scorerId) {
+                  updatedEvent.scorerId = playerIdMap.get(event.scorerId) || event.scorerId;
+                }
+                if (event.assisterId) {
+                  updatedEvent.assisterId = playerIdMap.get(event.assisterId) || event.assisterId;
+                }
+                return updatedEvent;
               }
-              if (event.assisterId) {
-                updatedEvent.assisterId = playerIdMap.get(event.assisterId) || event.assisterId;
-              }
-              return updatedEvent;
-            });
+            );
           }
           
           // Update season and tournament IDs

--- a/src/app/test-sentry/page.tsx
+++ b/src/app/test-sentry/page.tsx
@@ -55,7 +55,7 @@ export default function TestSentryPage() {
     addResult('Capturing exception manually...');
     try {
       // Intentionally cause an error
-      const obj: any = null;
+      const obj = null as unknown as { nonExistentMethod: () => void };
       obj.nonExistentMethod();
     } catch (error) {
       Sentry.captureException(error);

--- a/src/components/MigrationErrorBoundary.tsx
+++ b/src/components/MigrationErrorBoundary.tsx
@@ -13,10 +13,8 @@ import { safeLocalStorageGet } from '@/utils/safeJson';
 interface Props {
   children: ReactNode;
   componentName: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fallbackComponent?: React.ComponentType<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fallbackProps?: any;
+  fallbackComponent?: React.ComponentType<unknown>;
+  fallbackProps?: unknown;
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
 }
 
@@ -103,7 +101,7 @@ export class MigrationErrorBoundary extends Component<Props, State> {
     
     // Store error report for debugging
     try {
-      const existingReports = safeLocalStorageGet<any[]>('migration-error-reports', []);
+      const existingReports = safeLocalStorageGet<unknown[]>('migration-error-reports', []);
       existingReports.push(errorReport);
       // Keep only last 10 reports
       const recentReports = existingReports.slice(-10);

--- a/src/components/game/GameStateProvider.tsx
+++ b/src/components/game/GameStateProvider.tsx
@@ -158,7 +158,7 @@ export function GameStateProvider({
     logger.debug('[GameStateProvider] Pausing game');
     // Maintain current status; reduce to paused by toggling running flag
     // Delegate to reducer semantics rather than resetting status
-    dispatchGameSession({ type: 'PAUSE_TIMER' } as any);
+    dispatchGameSession({ type: 'PAUSE_TIMER' });
     setIsGameActive(false);
   }, []);
   

--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -4,11 +4,12 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/context/AuthContext';
 import { isUserAdmin, AdminRole, hasAdminRole } from '@/lib/auth/adminAuth';
+import type { User } from '@/types/supabase-types';
 
 export interface AdminAuthState {
   isAdmin: boolean;
   isLoading: boolean;
-  user: any;
+  user: User | null;
   role?: AdminRole;
   hasRole: (role: AdminRole) => boolean;
   checkingAuth: boolean;

--- a/src/hooks/useViewMode.ts
+++ b/src/hooks/useViewMode.ts
@@ -128,12 +128,8 @@ export interface UseViewModeResult {
 
 export function useViewMode(): UseViewModeResult {
   const { shouldUseLegacy } = useMigrationSafety('ViewMode');
-  
-  // Legacy fallback
-  if (shouldUseLegacy) {
-    return useLegacyViewMode();
-  }
-  
+  const legacyViewMode = useLegacyViewMode();
+
   // Get all the specialized hooks
   const gameView = useGameView();
   const _tacticsBoard = useTacticsBoard();
@@ -235,7 +231,11 @@ export function useViewMode(): UseViewModeResult {
   // ============================================================================
   // Return Interface
   // ============================================================================
-  
+
+  if (shouldUseLegacy) {
+    return legacyViewMode;
+  }
+
   return {
     // View modes
     viewModes: {


### PR DESCRIPTION
## Summary
- replace `any` types with safer alternatives across admin monitoring, backup import, Sentry test page, and error boundary
- refactor persistent storage and view mode hooks to avoid conditional hook usage and use `unknown` generics
- tighten admin auth state typing and remove stray `any` in game state provider

## Testing
- `npm run lint` *(fails: warnings remain in other files)*
- `npm test` *(fails: 1 failing suite, 4 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ba6ed4b6c832c8983a861f8752b6a